### PR TITLE
Celery should not run with superuser privileges

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,8 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
+RUN useradd -ms /bin/bash celeryuser
+
 WORKDIR /home/vcap/app/
 
 COPY requirements.txt .

--- a/manifest-base.yml
+++ b/manifest-base.yml
@@ -1,6 +1,6 @@
 ---
 
-command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5
+command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
 instances: 1
 memory: 1G
 health-check-type: none


### PR DESCRIPTION
Celery should not be be run as a root user for security reasons. A message is displayed on start-up.
"RuntimeWarning: You are running the worker with superuser privileges, which is absolutely not recommended!
Please specify a different user using the -uid option"

This change adds a celeryuser to the dockerfile and starts the celery application with the uid option which starts it under the user which has just been created.

* Added the creation of the celeryuser to the Dockerfile
* added the --uid option to the manifest which starts the app