### PR TITLE
Updated so celery runs as a non-root user

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
 
 RUN useradd -ms /bin/bash celeryuser
+RUN usermod -a -G clamav celeryuser
 
 WORKDIR /home/vcap/app/
 


### PR DESCRIPTION
The celeryuser didn't have permission to access the clamav unix socket. Adding the user to the clamav group will allow the user to access that socket.

* Added the celeryuser to the clamav group