### PR TITLE
Split workers and API manifests into separate templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ DEPLOY_BUILD_NUMBER ?= ${BUILD_NUMBER}
 DOCKER_CONTAINER_PREFIX = ${USER}-${BUILD_TAG}
 
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
-CF_MANIFEST_FILE ?= manifest-${CF_SPACE}.yml
 
 CF_APP ?= notify-antivirus
+CF_MANIFEST_FILE ?= manifest$(subst notify-antivirus,,${CF_APP}).yml.j2
 
 CODEDEPLOY_PREFIX ?= notifications-antivirus
 
@@ -176,7 +176,7 @@ generate-manifest:
 	$(if $(shell which gpg2), $(eval export GPG=gpg2), $(eval export GPG=gpg))
 	$(if ${GPG_PASSPHRASE_TXT}, $(eval export DECRYPT_CMD=echo -n $$$${GPG_PASSPHRASE_TXT} | ${GPG} --quiet --batch --passphrase-fd 0 --pinentry-mode loopback -d), $(eval export DECRYPT_CMD=${GPG} --quiet --batch -d))
 
-	@jinja2 --strict manifest.yml.j2 \
+	@jinja2 --strict ${CF_MANIFEST_FILE} \
 	    -D environment=${CF_SPACE} --format=yaml \
 	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/paas/environment-variables.gpg) 2>&1
 

--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -1,15 +1,18 @@
 ---
 
 applications:
-  - name: notify-antivirus
+  - name: notify-antivirus-api
 
-    command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
+    command: ./scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
     instances: 1
     memory: 1G
     health-check-type: none
 
+    routes:
+      - route: notify-antivirus-{{ environment }}.cloudapps.digital
+
     env:
-      NOTIFY_APP_NAME: notify-antivirus
+      NOTIFY_APP_NAME: notify-antivirus-api
       CW_APP_NAME: antivirus
       STATSD_ENABLED: 1
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
@@ -20,3 +23,5 @@ applications:
       AWS_SECRET_ACCESS_KEY: '{{ AWS_SECRET_ACCESS_KEY }}'
       STATSD_PREFIX: '{{ STATSD_PREFIX }}'
       NOTIFICATION_QUEUE_PREFIX: '{{ NOTIFICATION_QUEUE_PREFIX }}'
+
+      ANTIVIRUS_API_KEY: '{{ ANTIVIRUS_API_KEY }}'


### PR DESCRIPTION
Older versions of CF CLI do not support additional arguments when
deploying one application from a multi-app manifest, which we need
in order to deploy a docker container.

This is fixed in CF CLI >6.34, but we can't upgrade the CLI package
on our CI instance since the new version of CF CLI breaks process
substitution when used with deprecated manifest features (like top
level keys), which are used in api, admin and template preview apps.

To avoid the issue for now we split the manifest template into 2
single-app manifests: one for the celery app and one for the API.