### PR TITLE
Don't bind a default route to the celery workers app

### DIFF
--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -8,6 +8,8 @@ applications:
     memory: 1G
     health-check-type: none
 
+    no-route: true
+
     env:
       NOTIFY_APP_NAME: notify-antivirus
       CW_APP_NAME: antivirus


### PR DESCRIPTION
CF will try to bind a `<app-name>.cloudapps.digital` route to an
app if one is not specified in the manifest. Since we don't have
any endpoints on the celery workers app we can skip this step.