### PR TITLE
Copy gunicorn config file to the PaaS Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -40,6 +40,7 @@ RUN pip install -r requirements.txt
 COPY app app
 COPY application.py .
 COPY run_celery.py .
+COPY gunicorn_config.py .
 COPY Makefile .
 
 COPY scripts/run_app.sh scripts/run_app.sh


### PR DESCRIPTION
Dockerfile is copying individual files instead of using a dockerignore
whitelist, so we need to add an instruction to add the new gunicorn
config file to the image.