### PR TITLE
Add gunicorn to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ celery==3.1.25
 boto3==1.6.4
 
 Flask-HTTPAuth==3.2.3
+gunicorn==19.7.1
 
 # PaaS
 awscli-cwlogs>=1.4,<1.5


### PR DESCRIPTION
Package needs to be installed in order to run gunicorn on PaaS.