### PR TITLE
ClamAV database isn't being updated

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,9 @@ RUN mkdir /var/run/clamav && \
 
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf && \
-    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf
+    sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/freshclam.conf && \
+    sed -i 's/^Checks .*$/Checks 12/g' /etc/clamav/freshclam.conf && \
+    printf "# Proxy: http://egress.internal:8080\\n# HTTPProxyServer egress.internal\\n# HTTPProxyPort 8080" >> /etc/clamav/freshclam.conf
 
 RUN useradd -ms /bin/bash celeryuser
 RUN usermod -a -G clamav celeryuser

--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -6,6 +6,7 @@ applications:
     command: ./scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
     instances: 1
     memory: 1G
+    disk_quota: 2G
     health-check-type: none
 
     routes:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -6,6 +6,7 @@ applications:
     command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
     instances: 1
     memory: 1G
+    disk_quota: 2G
     health-check-type: none
 
     no-route: true


### PR DESCRIPTION
The clamav database isn't being updated as lines are being added to the conf file which point it to a proxy egress.internal and therefore an error is produced "an't get information about egress.internal: Name or service not known". Removing this setting meeans the update works.

* Updated the dockerfile to create the config options Proxy, HTTPProxyServer and HTTPProxyPort and comment them out, freshclam (the process for performing the update) doesn't then add them automatically.
* Updated the manifest to increase the disk size to 2G as the 1G default isn't enough to be able to download the updates and apply them.