### PR TITLE
Increase PaaS memory limit to 2G per instance

### DIFF
--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -5,7 +5,7 @@ applications:
 
     command: ./scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
     instances: 1
-    memory: 1G
+    memory: 2G
     disk_quota: 2G
     health-check-type: none
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -5,7 +5,7 @@ applications:
 
     command: ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
     instances: 1
-    memory: 1G
+    memory: 2G
     disk_quota: 2G
     health-check-type: none
 


### PR DESCRIPTION
clamd takes around 570MB of memory after start-up. Combined with ~55MB for each of 6 celery processes we're using 900MB without any load. When the workers start processing tasks it's likely that the memory usage spikes past the 1GB limit and leads to OOM killer terminating the clamd process, which makes the instance start failing letter scanning tasks.

Raising the quota to 2GB should give us a little more breathing room.

Applying the same to the API instances. They're using ~800Mb on average without any requests going through.
