### PR TITLE
Fix PHONY target name, pin base image and update ClamAV version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endef
 run-with-docker: prepare-docker-build-image ## Build inside a Docker container
 	$(call run_docker_container,celery-build, make _run)
 
-.PHONY: run-with-docker
+.PHONY: run-app-with-docker
 run-app-with-docker: prepare-docker-build-image ## Build inside a Docker container
 	$(call run_docker_container,app-build, make _run_app, -p 6016:6016)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim as parent
+FROM python:3.6-slim-jessie as parent
 
 ENV CLAMAV_VERSION 0.99
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim-jessie as parent
 
-ENV CLAMAV_VERSION 0.99
+ENV CLAMAV_VERSION 0.100
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
There were two PHONY targets with the name `run-with-docker` - one of these should be `run-app-with-docker`.

In order to fix the failing build, pinned the base image and updated the ClamAV version from 0.99 to 0.100.