### PR TITLE
Enable statsd by default

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -18,7 +18,7 @@ class QueueNames(object):
 class Config(object):
     # Hosted graphite statsd prefix
     STATSD_PREFIX = os.getenv('STATSD_PREFIX')
-    STATSD_ENABLED = False
+    STATSD_ENABLED = True
     STATSD_HOST = os.getenv('STATSD_HOST')
     STATSD_PORT = 8125
 
@@ -73,7 +73,6 @@ class Development(Config):
 
 class Test(Config):
     DEBUG = True
-    STATSD_ENABLED = True
     STATSD_HOST = "localhost"
     STATSD_PORT = 1000
 
@@ -88,13 +87,11 @@ class Preview(Config):
 
 
 class Staging(Config):
-    STATSD_ENABLED = True
 
     LETTERS_SCAN_BUCKET_NAME = 'staging-letters-scan'
 
 
 class Production(Config):
-    STATSD_ENABLED = True
 
     LETTERS_SCAN_BUCKET_NAME = 'production-letters-scan'
 

--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -15,7 +15,7 @@ applications:
     env:
       NOTIFY_APP_NAME: notify-antivirus-api
       CW_APP_NAME: antivirus
-      STATSD_ENABLED: 1
+      STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
       REDIS_URL: '{{ REDIS_URL }}'
 

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -12,7 +12,6 @@ applications:
     env:
       NOTIFY_APP_NAME: notify-antivirus
       CW_APP_NAME: antivirus
-      STATSD_ENABLED: 1
       STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
       REDIS_ENABLED: '{{ REDIS_ENABLED }}'
       REDIS_URL: '{{ REDIS_URL }}'


### PR DESCRIPTION
When changing the statsd host the functional tests didn't catch an error in the config because statsd was not enabled in preview.

This PR enables statsd by default.

Add missing statsd host config to manifest file. 
Remove statsd enable config - it's set by default in the config file.