### PR TITLE
Disable Statsd in development

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -65,6 +65,7 @@ class Config(object):
 class Development(Config):
     NOTIFICATION_QUEUE_PREFIX = 'development'
     DEBUG = True
+    STATSD_ENABLED = False
 
     ANTIVIRUS_API_KEY = 'test-key'
 


### PR DESCRIPTION
Statsd is now enabled by default, but we don't need it in development.