### PR TITLE
Don't cache virus definitions and don't run clamd as a background process

### DIFF
--- a/app/views.py
+++ b/app/views.py
@@ -1,3 +1,5 @@
+import clamd
+
 from flask import Blueprint, current_app, jsonify, request
 from flask_httpauth import HTTPTokenAuth
 
@@ -10,6 +12,11 @@ auth = HTTPTokenAuth()
 
 @main_blueprint.route('/_status')
 def status():
+    try:
+        clamd.ClamdUnixSocket().ping()
+    except Exception:
+        return '', 500
+
     return 'ok', 200
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,7 @@ RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
     chmod 750 /var/run/clamav
 
-RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
-    echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
+RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 
 
 ##### Test Image ##############################################################

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim-jessie as parent
 
-ENV CLAMAV_VERSION 0.100
+ENV CLAMAV_VERSION 0.100.3+dfsg-0+deb8u1
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -10,11 +10,6 @@ RUN apt-get update && \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
-RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
-    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
-    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
-    chown clamav:clamav /var/lib/clamav/*.cvd
 
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
@@ -35,6 +30,11 @@ COPY requirements_for_test.txt requirements_for_test.txt
 RUN pip install -r requirements_for_test.txt
 
 COPY . .
+
+RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
+    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
+    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
+    chown clamav:clamav /var/lib/clamav/*.cvd
 
 ADD scripts/run_celery.sh /
 
@@ -67,5 +67,10 @@ ARG CI_BUILD_URL
 ENV CI_NAME=$CI_NAME
 ENV CI_BUILD_NUMBER=$CI_BUILD_NUMBER
 ENV CI_BUILD_URL=$CI_BUILD_URL
+
+RUN wget -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
+    wget -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
+    wget -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \
+    chown clamav:clamav /var/lib/clamav/*.cvd
 
 RUN make _generate-version-file

--- a/scripts/run_app.sh
+++ b/scripts/run_app.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-clamd &
-# sleep for because clamav needs to start and maybe download the virus database
-sleep 15
+clamd
 
 flask run -p 6016 -h 0.0.0.0

--- a/scripts/run_app_paas.sh
+++ b/scripts/run_app_paas.sh
@@ -62,10 +62,7 @@ function on_exit {
 }
 
 function start_clamd {
-  clamd &
-  CLAMD_PID=$!
-  echo "clamd pid: ${CLAMD_PID}"
-  sleep 15
+  clamd
 }
 
 function start_application {
@@ -83,7 +80,7 @@ function start_aws_logs_agent {
 function run {
   while true; do
     kill -0 ${APP_PID} 2&>/dev/null || break
-    kill -0 ${CLAMD_PID} 2&>/dev/null || start_clamd
+    python -c "import clamd, sys; clamd.ClamdUnixSocket().ping()" || break
     kill -0 ${AWSLOGS_AGENT_PID} 2&>/dev/null || start_aws_logs_agent
     sleep 1
   done

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -2,6 +2,6 @@
 
 set -e
 
-clamd &
-# sleep for because clamav needs to start and maybe download the virus database
-sleep 15; celery -A run_celery.notify_celery worker --pidfile="/tmp/celery-celery.pid" --loglevel=INFO --concurrency=10
+clamd
+
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery-celery.pid" --loglevel=INFO --concurrency=10

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,2 +1,0 @@
-def test_that_the_tests_are_configured():
-    assert 1 == 1

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -4,10 +4,20 @@ import json
 from flask import url_for
 
 
-def test_status(client):
+def test_status_when_clamd_is_running(mocker, client):
+    mocker.patch('app.views.clamd.ClamdUnixSocket.ping', return_value='PONG')
+
     response = client.get(url_for('main.status'))
     assert response.status_code == 200
     assert response.get_data(as_text=True) == 'ok'
+
+
+def test_status_when_clamd_returns_error(mocker, client):
+    mocker.patch('app.views.clamd.ClamdUnixSocket.ping', side_effect=FileNotFoundError())
+
+    response = client.get(url_for('main.status'))
+    assert response.status_code == 500
+    assert response.get_data(as_text=True) == ''
 
 
 def test_scan_document_no_auth(client, mocker):


### PR DESCRIPTION
**Stopped caching the virus definitions in the Dockerfile**
We now get the new virus definitions after getting the `CI_BUILD_NUMBER` (which always changes) so that we don't use cached definitions.

**Updated the version of clamav-daemon**
To the latest available version for Jessie.

**Stopped starting clamd as a background proccess**
The docs say that clamd should not be started as a background process - instead you should run `clamd` which will load the database and then daemonize itself.

This change means that we can't rely on getting clamd's PID to check if it is running, because the PID will change once clamd daemonizes itself. To check if it's running we now ping clamd instead, and we also add this as a check to the `/_status` endpoint.

Since antivirus will take a little longer to start, we will increase the healthcheck timeout.

[Pivotal story](https://www.pivotaltracker.com/story/show/168292416)

These changes should (hopefully 🤞) mean that there is no downtime when we deploy antivirus - we won't need to make as many updates to the virus definitions when clamd is starting and we've changed the way that we  check if it's running.