### PR TITLE
Bump clamav version to fix build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim-jessie as parent
 
-ENV CLAMAV_VERSION 0.100.3+dfsg-0+deb8u1
+ENV CLAMAV_VERSION 0.101.4+dfsg-0+deb8u2
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Our build was passing on jenkins because it was
using it's cache. However when trying to run this on
concourse it did not have the old version of clamav in
its cache and failed to build as the version is no longer
available through apt-get.

Two versions are available through apt-get at the moment:
clamav-daemon/oldoldstable 0.101.4+dfsg-0+deb8u2 amd64
clamav-daemon/oldoldstable 0.100.0+dfsg-0+deb8u1 amd64

I've bumped us to the latest.