### PR TITLE
Change test WORKDIR from /app to /home/vcap/app

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,12 +17,11 @@ RUN mkdir /var/run/clamav && \
 
 RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 
+WORKDIR /home/vcap/app/
 
 ##### Test Image ##############################################################
 
 FROM parent as test
-
-WORKDIR /app
 
 COPY requirements.txt requirements.txt
 COPY requirements_for_test.txt requirements_for_test.txt
@@ -44,8 +43,6 @@ CMD ["/run_celery.sh"]
 FROM parent as production
 
 RUN useradd -ms /bin/bash celeryuser && usermod -a -G clamav celeryuser
-
-WORKDIR /home/vcap/app/
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt


### PR DESCRIPTION
We are doing this change for consistency. Antivirus app and template
preview app share job templates in Concourse. Both Template Preview
and Antivirus production have WORKDIR of /home/vcap/app, so it is
good to bring test WORKDIR in line with the above.