### PR TITLE
Tidy up Dockerfile, README and Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,10 @@ source environment.sh
 
 ##  To run the application
 
-The simplest way to run the application, is to run it inside a docker instance (recommended)
+The simplest way to run the application, is to run it inside a Docker container:
 
 ```
 make run-with-docker
-```
-
-Or to run it in a virtualenv (Nb. OS level dependencies such as ClamAV, should be resolved manually)
-Run `pip install -r requirements.txt` to install Python dependencies.
-
-```
-scripts/run_celery.sh
 ```
 
 ##  To test the application

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -57,13 +57,6 @@ COPY scripts/run_app.sh scripts/run_app.sh
 COPY scripts/run_celery.sh scripts/run_celery.sh
 COPY scripts/run_app_paas.sh scripts/run_app_paas.sh
 
-ARG CI_NAME
-ARG CI_BUILD_NUMBER
-ARG CI_BUILD_URL
-ENV CI_NAME=$CI_NAME
-ENV CI_BUILD_NUMBER=$CI_BUILD_NUMBER
-ENV CI_BUILD_URL=$CI_BUILD_URL
-
 RUN wget -nv -O /var/lib/clamav/main.cvd http://database.clamav.net/main.cvd && \
     wget -nv -O /var/lib/clamav/daily.cvd http://database.clamav.net/daily.cvd && \
     wget -nv -O /var/lib/clamav/bytecode.cvd http://database.clamav.net/bytecode.cvd && \


### PR DESCRIPTION
- Remove args to do with Jenkins egress proxy as we no longer test or
  deploy this through Jenkins so no longer needed
- Removed unused variables and functions after move to Concourse,
  ie `DOCKER_TTY`, `CF_HOME`, `CODEDEPLOY_PREFIX`,
  `build-paas-artifact`, `upload-paas-artifact`
- Remove the premise of build tags and deploy tags, we don't use these
  on concourse and they are not used in the antivirus app either so add
  little value
- Remove instructions for running not in Docker, devs only run this in
  Docker

The general approach here is to follow the changes made for the
template-preview app which also runs in production in docker. Hopefully
the local development and deployment processes for these two apps are
very similar now.