### PR TITLE
Remove redis keys

### DIFF
--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -19,8 +19,6 @@ applications:
       NOTIFY_APP_NAME: notify-antivirus-api
       CW_APP_NAME: antivirus
       STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
-      REDIS_ENABLED: '{{ REDIS_ENABLED }}'
-      REDIS_URL: '{{ REDIS_URL }}'
 
       # Credentials variables
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -16,8 +16,6 @@ applications:
       NOTIFY_APP_NAME: notify-antivirus
       CW_APP_NAME: antivirus
       STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
-      REDIS_ENABLED: '{{ REDIS_ENABLED }}'
-      REDIS_URL: '{{ REDIS_URL }}'
 
       # Credentials variables
       AWS_ACCESS_KEY_ID: '{{ AWS_ACCESS_KEY_ID }}'


### PR DESCRIPTION
We don't appear to use redis in the antivirus app so these environment variables
seem redundant and confusing.