### PR TITLE
Update Clamav to latest version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim as parent
 
-ENV CLAMAV_VERSION 0.101.4
+ENV CLAMAV_VERSION 0.102.1
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
The Concourse build starting failing with `Version '0.101.4*' for
'clamav-daemon' was not found`, and version `0.102.1` of Clamav is available for Buster, so let's use that.