### PR TITLE
Update Clamav version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim as parent
 
-ENV CLAMAV_VERSION 0.102.1
+ENV CLAMAV_VERSION 0.102.2
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
We had specified that clamav-daemon should use version `0.102.1` (the
stable version), but version `0.102.2+dfsg-0+deb10u1` (the stable updates
version) was being installed, so this changes the Dockerfile to use version
`0.102.2`.