### PR TITLE
Send letters that have passed virus scan to new api task

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -19,7 +19,7 @@ def scan_file(self, filename):
     try:
 
         if clamav_scan(BytesIO(_get_letter_pdf(filename))):
-            task_name = 'process-virus-scan-passed'
+            task_name = 'sanitise-letter'
         else:
             task_name = 'process-virus-scan-failed'
             current_app.logger.error('VIRUS FOUND for file: {}'.format(filename))

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -5,7 +5,7 @@ case $NOTIFY_APP_NAME in
     ./scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
     ;;
   notify-antivirus)
-    ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser`
+    ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=5 --uid=`id -u celeryuser` 2> /dev/null
     ;;
   *)
     echo "Unknown notify_app_name $NOTIFY_APP_NAME"

--- a/scripts/run_celery.sh
+++ b/scripts/run_celery.sh
@@ -4,4 +4,4 @@ set -e
 
 clamd
 
-celery -A run_celery.notify_celery worker --pidfile="/tmp/celery-celery.pid" --loglevel=INFO --concurrency=10
+celery -A run_celery.notify_celery worker --pidfile="/tmp/celery-celery.pid" --loglevel=INFO --concurrency=10 2> /dev/null

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -16,7 +16,7 @@ def test_scan_no_virus(notify_antivirus, mocker):
     scan_file(TEST_FILENAME)
 
     mock_send_task.assert_called_once_with(
-        name='process-virus-scan-passed',
+        name='sanitise-letter',
         kwargs={'filename': TEST_FILENAME},
         queue=QueueNames.LETTERS,
     )


### PR DESCRIPTION
Instead of antivirus calling `process-virus-scan-passed` in notifications-api, we now want to call the `sanitise-letter` task in notifications-api instead. The `sanitise-letter` task calls the template-preview task to sanitise letters.

Also adds a change to ignore Celery logs by redirecting to `/dev/null` like we do in our delivery apps when running in production.

https://www.pivotaltracker.com/story/show/171359191