### PR TITLE
Update clamav version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim as parent
 
-ENV CLAMAV_VERSION 0.102.2
+ENV CLAMAV_VERSION 0.102.3
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
We had specified that clamav-daemon should use version `0.102.2`, but clamav-base version `0.102.3` is getting automatically installed (not quite sure how), so this keeps the versions consistent and stops errors.