### PR TITLE
Bump ClamAV version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim as parent
 
-ENV CLAMAV_VERSION 0.102.3
+ENV CLAMAV_VERSION 0.102.4
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
There was a security patch for version 0.102.3, 0.102.4 is the latest secure version