### PR TITLE
Bump memory on paas to 4gb per app to stop app crashing at start

### DIFF
--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -3,7 +3,7 @@
 applications:
   - name: notify-antivirus-api
 
-    memory: 2G
+    memory: 4G
     disk_quota: 2G
 
     routes:

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -3,7 +3,7 @@
 applications:
   - name: notify-antivirus
 
-    memory: 2G
+    memory: 4G
     disk_quota: 2G
     health-check-type: process
     routes:


### PR DESCRIPTION
We don't yet know why it's doing it, but this is an important hot fix to
keep the ability for things to work until we do. We've tested on preview
with an app and it managed to start up OK