### PR TITLE
Revamp Celery stats and request tracing

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,9 +24,9 @@ def create_app(application):
 
     init_app(application)
 
-    notify_celery.init_app(application)
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
+    notify_celery.init_app(application)
 
     application.register_blueprint(main_blueprint)
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,7 +2,7 @@ import os
 import time
 
 from flask import g, jsonify, request
-from notifications_utils import logging
+from notifications_utils import logging, request_helper
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
 
 from app.celery.celery import NotifyCelery
@@ -26,6 +26,7 @@ def create_app(application):
 
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)
+    request_helper.init_app(application)
     notify_celery.init_app(application)
 
     application.register_blueprint(main_blueprint)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,7 +1,8 @@
 import time
 
 from celery import Celery, Task
-from flask import g
+from flask import g, request
+from flask.ctx import has_app_context, has_request_context
 
 
 def make_task(app):
@@ -59,6 +60,16 @@ def make_task(app):
 
                 return super().__call__(*args, **kwargs)
 
+        def apply_async(self, args=None, kwargs=None, **other_kwargs):
+            kwargs = kwargs or {}
+
+            if has_request_context() and hasattr(request, 'request_id'):
+                kwargs['request_id'] = request.request_id
+            elif has_app_context() and 'request_id' in g:
+                kwargs['request_id'] = g.request_id
+
+            return super().apply_async(args, kwargs, **other_kwargs)
+
     return NotifyTask
 
 
@@ -73,3 +84,13 @@ class NotifyCelery(Celery):
         )
 
         self.conf.update(app.config['CELERY'])
+
+    def send_task(self, name, args=None, kwargs=None, **other_kwargs):
+        kwargs = kwargs or {}
+
+        if has_request_context() and hasattr(request, 'request_id'):
+            kwargs['request_id'] = request.request_id
+        elif has_app_context() and 'request_id' in g:
+            kwargs['request_id'] = g.request_id
+
+        return super().send_task(name, args, kwargs, **other_kwargs)

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,22 +1,62 @@
+import time
+
 from celery import Celery, Task
+from flask import g
 
 
 def make_task(app):
-    # this task is nested so that it has access to the original flask application - when celery restarts processes,
-    # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
-    # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
     class NotifyTask(Task):
         abstract = True
+        start = None
+
+        def on_success(self, retval, task_id, args, kwargs):
+            elapsed_time = time.monotonic() - self.start
+            delivery_info = self.request.delivery_info or {}
+            queue_name = delivery_info.get('routing_key', 'none')
+
+            app.logger.info(
+                "Celery task {task_name} (queue: {queue_name}) took {time}".format(
+                    task_name=self.name,
+                    queue_name=queue_name,
+                    time="{0:.4f}".format(elapsed_time)
+                )
+            )
+
+            app.statsd_client.timing(
+                "celery.{queue_name}.{task_name}.success".format(
+                    task_name=self.name,
+                    queue_name=queue_name
+                ), elapsed_time
+            )
 
         def on_failure(self, exc, task_id, args, kwargs, einfo):
-            # ensure task will log exceptions to correct handlers
-            with app.app_context():
-                app.logger.exception('Celery task {} failed'.format(self.name))
-                super().on_failure(exc, task_id, args, kwargs, einfo)
+            delivery_info = self.request.delivery_info or {}
+            queue_name = delivery_info.get('routing_key', 'none')
+
+            app.logger.exception(
+                "Celery task {task_name} (queue: {queue_name}) failed".format(
+                    task_name=self.name,
+                    queue_name=queue_name,
+                )
+            )
+
+            app.statsd_client.incr(
+                "celery.{queue_name}.{task_name}.failure".format(
+                    task_name=self.name,
+                    queue_name=queue_name
+                )
+            )
+
+            super().on_failure(exc, task_id, args, kwargs, einfo)
 
         def __call__(self, *args, **kwargs):
             # ensure task has flask context to access config, logger, etc
             with app.app_context():
+                self.start = time.monotonic()
+                # Remove piggyback values from kwargs
+                # Add 'request_id' to 'g' so that it gets logged
+                g.request_id = kwargs.pop('request_id', None)
+
                 return super().__call__(*args, **kwargs)
 
     return NotifyTask

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -60,16 +60,6 @@ def make_task(app):
 
                 return super().__call__(*args, **kwargs)
 
-        def apply_async(self, args=None, kwargs=None, **other_kwargs):
-            kwargs = kwargs or {}
-
-            if has_request_context() and hasattr(request, 'request_id'):
-                kwargs['request_id'] = request.request_id
-            elif has_app_context() and 'request_id' in g:
-                kwargs['request_id'] = g.request_id
-
-            return super().apply_async(args, kwargs, **other_kwargs)
-
     return NotifyTask
 
 

--- a/app/celery/celery.py
+++ b/app/celery/celery.py
@@ -1,30 +1,35 @@
 from celery import Celery, Task
 
 
+def make_task(app):
+    # this task is nested so that it has access to the original flask application - when celery restarts processes,
+    # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
+    # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
+    class NotifyTask(Task):
+        abstract = True
+
+        def on_failure(self, exc, task_id, args, kwargs, einfo):
+            # ensure task will log exceptions to correct handlers
+            with app.app_context():
+                app.logger.exception('Celery task {} failed'.format(self.name))
+                super().on_failure(exc, task_id, args, kwargs, einfo)
+
+        def __call__(self, *args, **kwargs):
+            # ensure task has flask context to access config, logger, etc
+            with app.app_context():
+                return super().__call__(*args, **kwargs)
+
+    return NotifyTask
+
+
 class NotifyCelery(Celery):
 
     def init_app(self, app):
-        # this task is nested so that it has access to the original flask application - when celery restarts processes,
-        # it doesn't appear to execute the whole import process again, and as such, flask.current_app no longer has
-        # a context, and throws a RuntimeError. So we need to create an app context from scratch each time.
-        class NotifyTask(Task):
-            abstract = True
-
-            def on_failure(self, exc, task_id, args, kwargs, einfo):
-                # ensure task will log exceptions to correct handlers
-                with app.app_context():
-                    app.logger.exception('Celery task {} failed'.format(self.name))
-                    super().on_failure(exc, task_id, args, kwargs, einfo)
-
-            def __call__(self, *args, **kwargs):
-                # ensure task has flask context to access config, logger, etc
-                with app.app_context():
-                    return super().__call__(*args, **kwargs)
 
         super().__init__(
             app.import_name,
             broker=app.config['CELERY']['broker_url'],
-            task_cls=NotifyTask,
+            task_cls=make_task(app),
         )
 
         self.conf.update(app.config['CELERY'])

--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -4,7 +4,6 @@ import boto3
 import clamd
 from botocore.exceptions import ClientError as BotoClientError
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 
 from app import notify_celery
 from app.clamav_client import clamav_scan
@@ -12,7 +11,6 @@ from app.config import QueueNames
 
 
 @notify_celery.task(bind=True, name="scan-file", max_retries=5, default_retry_delay=300)
-@statsd(namespace="antivirus")
 def scan_file(self, filename):
     current_app.logger.info('Scanning file: {}'.format(filename))
 

--- a/app/clamav_client.py
+++ b/app/clamav_client.py
@@ -1,9 +1,7 @@
 import clamd
 from flask import current_app
-from notifications_utils.statsd_decorators import statsd
 
 
-@statsd(namespace="antivirus")
 def clamav_scan(stream):
 
     cd = clamd.ClamdUnixSocket()

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 isort==5.7.0
 flake8==3.7.7
+freezegun==1.1.0
 pytest==4.6.3
 pytest-mock==1.10.4
 pytest-env==0.6.2

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -87,38 +87,6 @@ def test_call_exports_request_id_from_kwargs(mocker, celery_task):
     assert g.request_id == '1234'
 
 
-def test_apply_async_injects_global_request_id_into_kwargs(mocker, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-    g.request_id = '1234'
-    celery_task.apply_async()
-    super_apply.assert_called_with(None, {'request_id': '1234'})
-
-
-def test_apply_async_inject_request_id_with_other_kwargs(mocker, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-    g.request_id = '1234'
-    celery_task.apply_async(kwargs={'something': 'else'})
-    super_apply.assert_called_with(None, {'request_id': '1234', 'something': 'else'})
-
-
-def test_apply_async_inject_request_id_with_positional_args(mocker, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-    g.request_id = '1234'
-    celery_task.apply_async(['args'], {'something': 'else'})
-    super_apply.assert_called_with(['args'], {'request_id': '1234', 'something': 'else'})
-
-
-def test_apply_async_injects_id_into_kwargs_from_request(mocker, notify_antivirus, celery_task):
-    super_apply = mocker.patch('celery.app.task.Task.apply_async')
-    request_id_header = notify_antivirus.config['NOTIFY_TRACE_ID_HEADER']
-    request_headers = {request_id_header: '1234'}
-
-    with notify_antivirus.test_request_context(headers=request_headers):
-        celery_task.apply_async()
-
-    super_apply.assert_called_with(None, {'request_id': '1234'})
-
-
 def test_send_task_injects_global_request_id_into_kwargs(mocker, notify_antivirus):
     super_apply = mocker.patch('celery.Celery.send_task')
     g.request_id = '1234'

--- a/tests/celery/test_celery.py
+++ b/tests/celery/test_celery.py
@@ -1,0 +1,86 @@
+import uuid
+
+import pytest
+from freezegun import freeze_time
+
+from app import notify_celery
+
+
+# requiring notify_antivirus ensures notify_celery.init_app has been called
+@pytest.fixture(scope='session')
+def celery_task(notify_antivirus):
+    @notify_celery.task(name=uuid.uuid4(), base=notify_celery.task_cls)
+    def test_task(delivery_info=None):
+        pass
+
+    return test_task
+
+
+@pytest.fixture
+def async_task(celery_task):
+    celery_task.push_request(delivery_info={'routing_key': 'test-queue'})
+    yield celery_task
+    celery_task.pop_request()
+
+
+def test_success_should_log_and_call_statsd(mocker, notify_antivirus, async_task):
+    statsd = mocker.patch.object(notify_antivirus.statsd_client, 'timing')
+    logger = mocker.patch.object(notify_antivirus.logger, 'info')
+
+    with freeze_time() as frozen:
+        async_task()
+        frozen.tick(5)
+
+        async_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) took 5.0000')
+
+
+def test_success_queue_when_applied_synchronously(mocker, notify_antivirus, celery_task):
+    statsd = mocker.patch.object(notify_antivirus.statsd_client, 'timing')
+    logger = mocker.patch.object(notify_antivirus.logger, 'info')
+
+    with freeze_time() as frozen:
+        celery_task()
+        frozen.tick(5)
+
+        celery_task.on_success(
+            retval=None, task_id=1234, args=[], kwargs={}
+        )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.success', 5.0)
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) took 5.0000')
+
+
+def test_failure_should_log_and_call_statsd(mocker, notify_antivirus, async_task):
+    statsd = mocker.patch.object(notify_antivirus.statsd_client, 'incr')
+    logger = mocker.patch.object(notify_antivirus.logger, 'exception')
+
+    async_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.test-queue.{async_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {async_task.name} (queue: test-queue) failed')
+
+
+def test_failure_queue_when_applied_synchronously(mocker, notify_antivirus, celery_task):
+    statsd = mocker.patch.object(notify_antivirus.statsd_client, 'incr')
+    logger = mocker.patch.object(notify_antivirus.logger, 'exception')
+
+    celery_task.on_failure(
+        exc=Exception, task_id=1234, args=[], kwargs={}, einfo=None
+    )
+
+    statsd.assert_called_once_with(f'celery.none.{celery_task.name}.failure')
+    logger.assert_called_once_with(f'Celery task {celery_task.name} (queue: none) failed')
+
+
+def test_call_exports_request_id_from_kwargs(mocker, celery_task):
+    g = mocker.patch('app.celery.celery.g')
+    # this would fail if the kwarg was passed through unexpectedly
+    celery_task(request_id='1234')
+    assert g.request_id == '1234'


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/176261229

This applies the same change we made in the API, and goes a bit further
to enable end-to-end request tracing, which is part of the same code.

Please see the commit messages for more details. If we have concerns about
the request tracing part, I can split that into a separate PR.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)