### PR TITLE
Use -with-docker consistently in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ run-flask-with-docker: ## Run flask in Docker container
 	export DOCKER_ARGS="-p 6016:6016" && ./scripts/run_with_docker.sh ./scripts/run_app.sh
 
 .PHONY: test
-test: ## Run tests (used by Concourse)
+test: test-requirements ## Run tests (used by Concourse)
 	./scripts/run_tests.sh
 
 .PHONY: test-with-docker

--- a/Makefile
+++ b/Makefile
@@ -57,18 +57,22 @@ test-requirements:
 bootstrap: generate-version-file ## Setup environment to run app commands
 	docker build -f docker/Dockerfile --target test -t notifications-antivirus .
 
-.PHONY: run-celery
-run-celery: ## Run celery in Docker container
+.PHONY: run-celery-with-docker
+run-celery-with-docker: ## Run celery in Docker container
 	$(if ${NOTIFICATION_QUEUE_PREFIX},,$(error Must specify NOTIFICATION_QUEUE_PREFIX))
 	./scripts/run_with_docker.sh ./scripts/run_celery.sh
 
-.PHONY: run-flask
-run-flask: ## Run flask in Docker container
+.PHONY: run-flask-with-docker
+run-flask-with-docker: ## Run flask in Docker container
 	export DOCKER_ARGS="-p 6016:6016" && ./scripts/run_with_docker.sh ./scripts/run_app.sh
 
 .PHONY: test
-test: ## Run tests in Docker container
-	./scripts/run_with_docker.sh ./scripts/run_tests.sh
+test: ## Run tests (used by Concourse)
+	./scripts/run_tests.sh
+
+.PHONY: test-with-docker
+test-with-docker: ## Run tests in Docker container
+	./scripts/run_with_docker.sh make test
 
 .PHONY: upload-to-dockerhub
 upload-to-dockerhub: ## Upload the current version of the docker image to dockerhub

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Things to change:
 make bootstrap
 
 # run the web app
-make run-flask
+make run-flask-with-docker
 
 # run the background tasks
-make run-celery
+make run-celery-with-docker
 ```
 
 ##  To test the application
@@ -51,7 +51,7 @@ make run-celery
 # install dependencies, etc.
 make bootstrap
 
-make test
+make test-with-docker
 ```
 
 If you need to run a specific command, such as a single test, you can use the `run_with_docker.sh` script. This is what `test` and other `make` rules use.


### PR DESCRIPTION
This follows the same approach as in [1].

[1]: https://github.com/alphagov/notifications-template-preview/pull/537

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)