### PR TITLE
Make bootstrap task consistent with Docker repos

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+environment*.sh

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ help:
 generate-version-file:
 	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
+.PHONY: bootstrap
+bootstrap: generate-version-file
+	pip install -r requirements_for_test.txt
+
 .PHONY: freeze-requirements
 freeze-requirements:
 	rm -rf venv-freeze
@@ -53,8 +57,8 @@ test-requirements:
 
 # ---- DOCKER COMMANDS ---- #
 
-.PHONY: bootstrap
-bootstrap: generate-version-file ## Setup environment to run app commands
+.PHONY: bootstrap-with-docker
+bootstrap-with-docker: ## Setup environment to run app commands
 	docker build -f docker/Dockerfile --target test -t notifications-antivirus .
 
 .PHONY: run-celery-with-docker

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Reads jobs from a queue, using the supplied filename to fetch files from an S3 b
 This app uses dependencies that are difficult to install locally. In order to make local development easy, we run app commands through a Docker container. Run the following to set this up:
 
 ```shell
-  make bootstrap
+make bootstrap-with-docker
 ```
 
 Because the container caches things like Python packages, you will need to run this again if you change things like "requirements.txt".

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,11 +28,9 @@ WORKDIR /home/vcap/app/
 
 FROM parent as test
 
-COPY requirements.txt requirements.txt
-COPY requirements_for_test.txt requirements_for_test.txt
-RUN pip install -r requirements_for_test.txt
-
 COPY . .
+
+RUN make bootstrap
 
 ##### Production Image #######################################################
 


### PR DESCRIPTION
This follows the pattern established in [1].

[1]: https://github.com/alphagov/notifications-template-preview/pull/556




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)