### PR TITLE
Bump Clamav to version 0.103.3

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.6-slim as parent
 
-ENV CLAMAV_VERSION 0.103.2
+ENV CLAMAV_VERSION 0.103.3
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Only very small changes in this new version, so nothing that should
cause issues for us when upgrading.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
