### PR TITLE
Update base Docker image to python:3.9-slim

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-slim as parent
+FROM python:3.9-slim as parent
 
 ENV CLAMAV_VERSION 0.103.3
 


### PR DESCRIPTION
Updates the base Docker image to the official Debian 3.9 Slim release.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
