### PR TITLE
Rewrite deploy task to support branch deployments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,7 @@ CF_API ?= api.cloud.service.gov.uk
 CF_ORG ?= govuk-notify
 CF_SPACE ?= development
 
-DOCKER_USER_NAME = govuknotify
-DOCKER_IMAGE = ${DOCKER_USER_NAME}/notifications-antivirus
+DOCKER_IMAGE = ghcr.io/alphagov/notify/notifications-antivirus
 DOCKER_IMAGE_TAG = $(shell git describe --always --dirty)
 DOCKER_IMAGE_NAME = ${DOCKER_IMAGE}:${DOCKER_IMAGE_TAG}
 
@@ -80,12 +79,12 @@ test: test-requirements ## Run tests (used by Concourse)
 test-with-docker: ## Run tests in Docker container
 	./scripts/run_with_docker.sh make test
 
-.PHONY: upload-to-dockerhub
-upload-to-dockerhub: ## Upload the current version of the docker image to dockerhub
+.PHONY: upload-to-docker-registry
+upload-to-docker-registry: ## Upload the current version of the docker image to Docker registry
 	docker build -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
-	$(if ${DOCKERHUB_USERNAME},,$(error Must specify DOCKERHUB_USERNAME))
-	$(if ${DOCKERHUB_PASSWORD},,$(error Must specify DOCKERHUB_PASSWORD))
-	@docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
+	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
+	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
+	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
 	docker push ${DOCKER_IMAGE_NAME}
 
 # ---- DEPLOYMENT ---- #


### PR DESCRIPTION
Previously these were focussed on DockerHub. While the recipes still
work, we no longer build images there and should stop relying on it.

This rewrites the "upload-to-dockerhub" recipe to make it agnostic
to the registry we use. Note that this recipe isn't used by Concourse,
which does the upload using a resource [1] and also has its own code
to deploy the app [2] i.e. it's safe to change the vars at the top.

[1]: https://github.com/alphagov/notifications-aws/blob/6ab0cdf1bea7bff5679d4b6479f5dd33832d4ddb/concourse/apps-pipeline.yml.j2#L281
[2]: https://github.com/alphagov/notifications-aws/blob/6ab0cdf1bea7bff5679d4b6479f5dd33832d4ddb/concourse/templates/macros.yml.j2#L169




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)