### PR TITLE
Bump utils to bring in latest NotifyCelery code

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ gunicorn==20.0.4
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@48.1.0#egg=notifications-utils==48.1.0
+git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn==20.0.4
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@48.1.0#egg=notifications-utils==48.1.0
+git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
 
 ## The following requirements were added by pip freeze:
 amqp==2.6.1


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180213914

The new version of the base class:

- Reenables Celery argument checking
- Removes redundant code

See here for more details [1]. This also brings in an additional
but irrelevant change, relating to broadcast polygons.

[1]: https://github.com/alphagov/notifications-utils/pull/921




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)