### PR TITLE
Pin more specific python parent image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim as parent
+FROM python:3.9.9-slim-bullseye as parent
 
 ENV CLAMAV_VERSION 0.103.3
 


### PR DESCRIPTION
This pins our parent docker image to the exact same image, just
more explicitely meaning we won't get caught out between builds
with say the debian version upgrading.

In time we should make it even more specific to point at a specific
SHA as suggested by the GDS Way:
https://gds-way.cloudapps.digital/manuals/programming-languages/docker.html#using-tags-and-digests-in-from-instructions



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
