### PR TITLE
Bump utils to 51.3.0

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -7,4 +7,4 @@ gunicorn==20.0.4
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ gunicorn==20.0.4
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@49.0.0#egg=notifications-utils==49.0.0
+git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0
 
 ## The following requirements were added by pip freeze:
 amqp==2.6.1


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/180693991

This app has nothing to do with broadcasts or CSVs - this upgrade
is to pull in new logging for the NotifyCelery base class [1].

[1]: https://github.com/alphagov/notifications-utils/blob/master/CHANGELOG.md#5130




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)