### PR TITLE
Bump celery to latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 clamd==1.0.2
 Flask==1.1.1
-celery[sqs]==4.4.0
+celery[sqs]==5.2.2
 Flask-HTTPAuth==3.3.0
 gunicorn==20.0.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile requirements.in
 #
-amqp==2.6.1
+amqp==5.0.9
     # via kombu
 awscli==1.21.8
     # via
@@ -17,9 +17,7 @@ billiard==3.6.4.0
 bleach==4.1.0
     # via notifications-utils
 boto3==1.19.8
-    # via
-    #   celery
-    #   notifications-utils
+    # via notifications-utils
 botocore==1.22.8
     # via
     #   awscli
@@ -27,7 +25,7 @@ botocore==1.22.8
     #   s3transfer
 cachetools==4.2.4
     # via notifications-utils
-celery[sqs]==4.4.0
+celery[sqs]==5.2.2
     # via -r requirements.in
 certifi==2021.10.8
     # via
@@ -38,7 +36,18 @@ charset-normalizer==2.0.7
 clamd==1.0.2
     # via -r requirements.in
 click==8.0.3
-    # via flask
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+    #   flask
+click-didyoumean==0.3.0
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
 colorama==0.4.3
     # via awscli
 docutils==0.15.2
@@ -73,7 +82,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.2.3
     # via celery
 markupsafe==2.0.1
     # via jinja2
@@ -87,10 +96,10 @@ packaging==21.2
     # via bleach
 phonenumbers==8.12.36
     # via notifications-utils
+prompt-toolkit==3.0.24
+    # via click-repl
 pyasn1==0.4.8
     # via rsa
-pycurl==7.44.1
-    # via celery
 pyparsing==2.4.7
     # via packaging
 pypdf2==1.26.0
@@ -130,6 +139,7 @@ six==1.16.0
     # via
     #   awscli-cwlogs
     #   bleach
+    #   click-repl
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils
@@ -139,10 +149,13 @@ urllib3==1.26.7
     # via
     #   botocore
     #   requests
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
+wcwidth==0.2.5
+    # via prompt-toolkit
 webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2


### PR DESCRIPTION
No reason for it not to be on version 5 like the rest of our apps



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
