### PR TITLE
Upgrade clamav at 0.103.5 to fix build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.9.9-slim-bullseye as parent
 
-ENV CLAMAV_VERSION 0.103.3
+ENV CLAMAV_VERSION 0.103.5
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \


### PR DESCRIPTION
Was failing before:

clamav-daemon : Depends: clamav-base (= 0.103.3+dfsg-0+deb11u1) but 0.103.5+dfsg-0+deb11u1 is to be installed



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
