### PR TITLE
Fix Docker environment breaking without version.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,8 @@ wheels/
 .installed.cfg
 *.egg
 
-# Auto-generated version file
+## A placeholder version of this file is still committed to avoid having to generate it for local
+## development. The committed file will get overwritten as part of building the Docker image.
 app/version.py
 
 # PyInstaller

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ generate-version-file:
 	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
-bootstrap: generate-version-file
+bootstrap:
 	pip install -r requirements_for_test.txt
 
 .PHONY: freeze-requirements

--- a/app/version.py
+++ b/app/version.py
@@ -1,0 +1,2 @@
+__commit__ = "fake-local-dev-sha"
+__time__ = "2022-03-15T12:55:24"


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181498273

This repeats the change in [^1].

[^1]: https://github.com/alphagov/notifications-template-preview/pull/641




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)