### PR TITLE
error if we get rate limited when updating clamav

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,11 @@ RUN mkdir /var/run/clamav && \
 
 RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 
-RUN freshclam
+# make sure we exit with status 1 if we've been rate limited. otherwise we risk
+# deploying this image with no definitions, which will fail to detect viruses!
+RUN ! freshclam --stdout | \
+    tee /dev/stderr | \
+    grep -q "received error code 429"
 
 WORKDIR /home/vcap/app/
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.9.9-slim-bullseye as parent
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ENV CLAMAV_VERSION 0.103.5
 
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.9.9-slim-bullseye as parent
 
+# make sure we exit if `freshclam` fails, even if the later pipe commands succeed.
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV CLAMAV_VERSION 0.103.5


### PR DESCRIPTION
Because concourse doesn't cache docker images, we always have to run freshclam to update from scratch every time we build a docker image. Normally this happens once a day, however, we sometimes build docker images more (if a later step of the docker file fails, or if we merge a change to antivirus). 

If it's rate limited, freshclam blocks updates for 24 hours, but it doesn't return an error code. Our docker build carries on but with no virus definitions, and when the app is deployed the functional tests will fail (correctly). This blocks all our pipelines until the rate limit clears and we can build a working docker image. We'd much rather just have to stay on an old image for a bit longer if we're rate-limited. To do so, we can detect this rate limit and error out of the docker build, meaning concourse will still use the old image for other dependent jobs.

Instead of checking error codes, instead we need to parse the log lines to look for the 429 error message. To do so we redirect output from clamav to stdout so grep can see it, but then tee it back to stderr so we still get viewable logs in our build output.

This behaviour from freshclam is included in their test cases (including the error code being 0) so it feels unlikely that this log line will change much soon. [^1]

[^1]: https://github.com/Cisco-Talos/clamav/blob/30561caff531dd7d0c16aba214399baf3fceab40/unit_tests/freshclam_test.py#L277-L282

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
