### PR TITLE
Fix build passing when freshclam hits a 429

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.9.9-slim-bullseye as parent
 
-# make sure we exit if `freshclam` fails, even if the later pipe commands succeed.
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
 ENV CLAMAV_VERSION 0.103.5
 
 RUN apt-get update && \
@@ -25,9 +22,10 @@ RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 
 # make sure we exit with status 1 if we've been rate limited. otherwise we risk
 # deploying this image with no definitions, which will fail to detect viruses!
-RUN ! freshclam --stdout | \
-    tee /dev/stderr | \
-    grep -q "received error code 429"
+# tee /dev/stderr means we can still see the full output from freshclam.
+RUN freshclam --stdout | tee /dev/stderr > freshclam.out
+RUN ! grep "received error code 429" freshclam.out
+RUN rm freshclam.out
 
 WORKDIR /home/vcap/app/
 


### PR DESCRIPTION
Using a piped command to fix this doesn't seem to work - we've had
several passing builds where freshclam has 429ed [^1].

This technique does work [^2].

The piped command also had a problem that it would "succeed" if the
"freshclam --stdout" command failed, due to the "!" at the start e.g.

      #5 [2/2] RUN ! eho "hi error" |    tee /dev/stderr |   grep -q error
      #5 sha256:db7f997518950e9fff1cf982bfff42a1c13c91b0c85da0ac5c031b6095c88b76
      #5 0.172 /bin/bash: line 1: eho: command not found
      #5 DONE 0.2s

Using this technique fixes that too.

[^1]: https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/build-antivirus-master/builds/155
[^2]: https://concourse.notify.tools/teams/notify/pipelines/apps/jobs/build-antivirus-master/builds/158




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)