### PR TITLE
Bump utils to 55.1.4 (no changes)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,4 @@ gunicorn==20.0.4
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@51.3.0#egg=notifications-utils==51.3.0
+git+https://github.com/alphagov/notifications-utils.git@55.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,9 +7,7 @@
 amqp==5.0.9
     # via kombu
 awscli==1.21.8
-    # via
-    #   awscli-cwlogs
-    #   notifications-utils
+    # via awscli-cwlogs
 awscli-cwlogs==1.4.6
     # via -r requirements.in
 billiard==3.6.4.0
@@ -88,7 +86,7 @@ markupsafe==2.0.1
     # via jinja2
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@51.3.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@55.1.4
     # via -r requirements.in
 orderedset==2.0.3
     # via notifications-utils


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181588331

This is also a good opportunity to remove the redundant egg spec in
the requirements, like we have in other repos.




---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)