### PR TITLE
Bump dependencies to latest versions

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 clamd==1.0.2
 Flask==2.1.1
 celery[sqs]==5.2.6
-Flask-HTTPAuth==3.3.0
+Flask-HTTPAuth==4.6.0
 gunicorn==20.0.4
 
 # PaaS

--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ clamd==1.0.2
 Flask==2.1.1
 celery[sqs]==5.2.6
 Flask-HTTPAuth==4.6.0
-gunicorn==20.0.4
+gunicorn==20.1.0
 
 # PaaS
 awscli-cwlogs==1.4.6

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 clamd==1.0.2
-Flask==1.1.1
+Flask==2.1.1
 celery[sqs]==5.2.2
 Flask-HTTPAuth==3.3.0
 gunicorn==20.0.4

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 clamd==1.0.2
 Flask==2.1.1
-celery[sqs]==5.2.2
+celery[sqs]==5.2.6
 Flask-HTTPAuth==3.3.0
 gunicorn==20.0.4
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ colorama==0.4.3
     # via awscli
 docutils==0.15.2
     # via awscli
-flask==1.1.1
+flask==2.1.1
     # via
     #   -r requirements.in
     #   flask-httpauth
@@ -68,6 +68,8 @@ gunicorn==20.0.4
     # via -r requirements.in
 idna==3.3
     # via requests
+importlib-metadata==4.11.3
+    # via flask
 itsdangerous==2.0.1
     # via
     #   flask
@@ -158,6 +160,8 @@ webencodings==0.5.1
     # via bleach
 werkzeug==2.0.2
     # via flask
+zipp==3.8.0
+    # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,7 +64,7 @@ geojson==2.5.0
     # via notifications-utils
 govuk-bank-holidays==0.10
     # via notifications-utils
-gunicorn==20.0.4
+gunicorn==20.1.0
     # via -r requirements.in
 idna==3.3
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ botocore==1.22.8
     #   s3transfer
 cachetools==4.2.4
     # via notifications-utils
-celery[sqs]==5.2.2
+celery[sqs]==5.2.6
     # via -r requirements.in
 certifi==2021.10.8
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ flask==2.1.1
     #   flask-httpauth
     #   flask-redis
     #   notifications-utils
-flask-httpauth==3.3.0
+flask-httpauth==4.6.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -1,9 +1,9 @@
 -r requirements.txt
-isort==5.7.0
-flake8==3.7.7
-freezegun==1.1.0
-pytest==4.6.3
-pytest-mock==1.10.4
+isort==5.10.1
+flake8==4.0.1
+freezegun==1.2.1
+pytest==7.1.1
+pytest-mock==3.7.0
 pytest-env==0.6.2
 
-jinja2-cli[yaml]==0.7.0
+jinja2-cli[yaml]==0.8.2


### PR DESCRIPTION
This updates all dependencies to their latest versions. There are some major version bumps, but I can't see anything in the changelogs that would affect our code.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
