### PR TITLE
Download Clamav signature database from s3 using PrivateMirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ freeze-requirements: ## create static requirements.txt
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: ## Setup environment to run app commands
-	docker build -f docker/Dockerfile --target test -t notifications-antivirus .
+	docker build -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.9.9-slim-bullseye as parent
 ENV CLAMAV_VERSION 0.103.5
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
 
-# Optionally install clamav database from private mirror: --build-arg CLAMAV_USE_MIRROR=true
-ARG CLAMAV_USE_MIRROR
+# Use clamav database from private mirror. Disable with: --build-arg CLAMAV_USE_MIRROR=false
+ARG CLAMAV_USE_MIRROR=true
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -23,7 +23,7 @@ RUN mkdir /var/run/clamav && \
     chmod 750 /var/run/clamav
 
 RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
-RUN if [ -n "$CLAMAV_USE_MIRROR" ] ; then echo "PrivateMirror ${CLAMAV_MIRROR_URL}" >> /etc/clamav/freshclam.conf ; fi
+RUN if [ "$CLAMAV_USE_MIRROR" = "true" ] ; then echo "PrivateMirror ${CLAMAV_MIRROR_URL}" >> /etc/clamav/freshclam.conf ; fi
 
 # make sure we exit with status 1 if we've been rate limited. otherwise we risk
 # deploying this image with no definitions, which will fail to detect viruses!

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.9.9-slim-bullseye as parent
 ENV CLAMAV_VERSION 0.103.5
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
 
-# Use clamav database from private mirror. Disable with: --build-arg CLAMAV_USE_MIRROR=false
+# Use clamav database from private mirror. Disable with: --build-arg CLAMAV_USE_MIRROR=false for local builds
 ARG CLAMAV_USE_MIRROR=true
 
 RUN apt-get update && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM python:3.9.9-slim-bullseye as parent
 
 ENV CLAMAV_VERSION 0.103.5
+ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
+
+# Optionally install clamav database from private mirror: --build-arg CLAMAV_USE_MIRROR=true
+ARG CLAMAV_USE_MIRROR
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
@@ -19,6 +23,7 @@ RUN mkdir /var/run/clamav && \
     chmod 750 /var/run/clamav
 
 RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
+RUN if [ -n "$CLAMAV_USE_MIRROR" ] ; then echo "PrivateMirror ${CLAMAV_MIRROR_URL}" >> /etc/clamav/freshclam.conf ; fi
 
 # make sure we exit with status 1 if we've been rate limited. otherwise we risk
 # deploying this image with no definitions, which will fail to detect viruses!


### PR DESCRIPTION
### Context

We are consistently hitting Clamav's signature database rate limit as we download a fresh copy with each build, often multiple times a day. For main branch builds, the container is built twice.

The recommended solution is to maintain a database mirror.

### What's changed?

I have created Concourse task to periodically sync ClamAV signature databases to a private S3 mirror:

 - alphagov/notifications-aws#1090

This PR keeps things the same for local development, so there are no extra steps involved to connect to the VPN to access the mirror. It will continue to use the public mirrors.

### PrivateMirror in CI
Using the `PrivateMirror` option, we can instead bypass the DNS signature checks and simply use the `if-modified-since` header to detect database updates. This allows us to use S3 as a suitable repository.

We can then periodically update the database signature files stored in S3 via an external process.

This will allow us to build this project multiple times a day without exceeding the rate limit.

PrivateMirror details:

```
This option allows you to easily point freshclam to private mirrors. 
If PrivateMirror is set, freshclam does not attempt to use DNS to determine whether 
its databases are out-of-date, instead it will use the If-Modified-Since request or directly 
check the headers of the remote database files. 
For each database, freshclam first attempts to download the CLD file. If that fails, it tries 
to download the CVD file. This option overrides DatabaseMirror, DNSDatabaseInfo and 
ScriptedUpdates. It can be used multiple times to provide fall-back mirrors.
```

### How to review

Check this branch out and run `make bootstrap-with-docker`. This should continue to use the public mirror for local builds. Developers do not need to be connected to the VPN.

To test a build using the private mirror, when connected the VPN you can run:

```
docker build -f docker/Dockerfile --target test -t notifications-antivirus .
```

**TODO**

- [x] Periodically synchronise signature database files to s3
- [x] Limit access to private mirror files