### PR TITLE
Allow ClamAV to drift to the latest version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.9.9-slim-bullseye as parent
 
-ENV CLAMAV_VERSION 0.103.5
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
 
 # Use clamav database from private mirror. Disable with: --build-arg CLAMAV_USE_MIRROR=false for local builds
@@ -10,8 +9,8 @@ RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         git \
         build-essential \
-        clamav-daemon=${CLAMAV_VERSION}* \
-        clamav-freshclam=${CLAMAV_VERSION}* \
+        clamav-daemon \
+        clamav-freshclam \
         libcurl4-openssl-dev \
         libssl-dev \
     && \


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181889734

This is a way of implicitly upgrading the package, noting that we
rebuild and redeploy this app daily anyway to get the latest virus
definitions. While it's possible the new version breaks something,
we are confident this will be detected and we can pin if needed.

Note: in practice this hasn't changed the version of ClamAV we're 
running as 103.5 is the latest version in the Debian package repo.


---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)