### PR TITLE
Make sure all existing packages are up-to-date

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,6 +6,7 @@ ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.g
 ARG CLAMAV_USE_MIRROR=true
 
 RUN apt-get update && \
+    apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         git \
         build-essential \


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/181889734

This is part of the work to setup image scanning to report any
security vulnerabilities, which we then need to fix. Currently
I'm seeing 6 issues reported for low-level OS packages. Adding
each package to the install list to upgrade it doesn't scale.

The base image should eventually update with newer versions, but
this seems to be slower than the rate of vulnerabilities, which
we want to fix immediately if we can. One way to apply the fixes
is to upgrade all base image packages to their latest versions.

Ideally we would only apply security updates, but I can't find a
simple way of doing this. Since we were letting the versions drift
anyway, the additional risk should be minimal. There's a fairly
compelling argument for the upgrade approach online [^1].

[^1]: https://pythonspeed.com/articles/security-updates-in-docker/





---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)