### PR TITLE
 Install python prod dependencies in base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,9 @@ RUN rm freshclam.out
 
 WORKDIR /home/vcap/app/
 
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
 ##### Test Image ##############################################################
 
 FROM parent as test
@@ -47,9 +50,6 @@ RUN make bootstrap
 FROM parent as production
 
 RUN useradd -ms /bin/bash celeryuser && usermod -a -G clamav celeryuser
-
-COPY requirements.txt .
-RUN pip install -r requirements.txt
 
 COPY app app
 COPY application.py .


### PR DESCRIPTION
 `make bootstrap` installs the `requirements_for_test` which installs
 them anyway

Similar to https://github.com/alphagov/notifications-template-preview/pull/673



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on continuous deployment](https://github.com/alphagov/notifications-manuals/wiki/Deploying-with-concourse#continuous-deployment)
