### PR TITLE
Make the location of the parent image configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ freeze-requirements: ## create static requirements.txt
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: ## Setup environment to run app commands
-	docker build -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
+	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container
@@ -71,7 +71,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=parent --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- DEPLOYMENT ---- #
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,4 @@
+ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-antivirus:base
 FROM python:3.9.9-slim-bullseye as parent
 
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
@@ -39,7 +40,7 @@ RUN pip install -r requirements.txt
 
 ##### Test Image ##############################################################
 
-FROM ghcr.io/alphagov/notify/notifications-antivirus:base as test
+FROM ${BASE_IMAGE} as test
 
 COPY . .
 
@@ -47,7 +48,7 @@ RUN make bootstrap
 
 ##### Production Image #######################################################
 
-FROM ghcr.io/alphagov/notify/notifications-antivirus:base as production
+FROM ${BASE_IMAGE} as production
 
 RUN useradd -ms /bin/bash celeryuser && usermod -a -G clamav celeryuser
 


### PR DESCRIPTION
This allows people to develop and test locally without having to
overwrite the base image in ghcr in order for the local build to work



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
