### PR TITLE
Add entrypoint.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,5 +61,6 @@ COPY Makefile .
 COPY scripts/run_app.sh scripts/run_app.sh
 COPY scripts/run_celery.sh scripts/run_celery.sh
 COPY scripts/run_app_paas.sh scripts/run_app_paas.sh
+COPY scripts/run_app_ecs.sh scripts/run_app_ecs.sh
 
 RUN make generate-version-file

--- a/scripts/run_app_ecs.sh
+++ b/scripts/run_app_ecs.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+TERMINATE_TIMEOUT=10
+
+function on_exit {
+  echo "Terminating application process with pid ${APP_PID}"
+  kill ${APP_PID} || true
+  n=0
+  while (kill -0 ${APP_PID} 2&>/dev/null); do
+    echo "Application is still running.."
+    sleep 1
+    let n=n+1
+    if [ "$n" -ge "$TERMINATE_TIMEOUT" ]; then
+      echo "Timeout reached, killing process with pid ${APP_PID}"
+      kill -9 ${APP_PID} || true
+      break
+    fi
+  done
+  echo "Application process terminated, waiting 10 seconds"
+  sleep 10
+  echo "Terminating remaining subprocesses.."
+  kill 0
+}
+
+function start_clamd {
+  clamd
+}
+
+function start_application {
+  exec "$@" &
+  APP_PID=`jobs -p`
+  echo "Application process pid: ${APP_PID}"
+}
+
+function run {
+  while true; do
+    kill -0 ${APP_PID} 2&>/dev/null || break
+    python -c "import clamd, sys; clamd.ClamdUnixSocket().ping()" || break
+    sleep 1
+  done
+}
+
+echo "Run script pid: $$"
+
+trap "on_exit" EXIT
+
+start_clamd
+
+# The application has to start first!
+start_application "$@"
+
+run


### PR DESCRIPTION
An entrypoint wrapper script has been added to start `clamd `in our
 ecs deployment of the antivirus app.

It differs from from the paas wrapper by not handling logging
 which is already handled in our terraform code