### PR TITLE
Connect to sqs using the new endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -30,11 +30,13 @@ class Config(object):
     ANTIVIRUS_API_KEY = os.getenv('ANTIVIRUS_API_KEY')
 
     CELERY = {
-        'broker_url': 'sqs://',
+        'broker_url': 'https://sqs.eu-west-1.amazonaws.com',
+        'broker_transport': 'sqs',
         'broker_transport_options': {
             'region': AWS_REGION,
             'visibility_timeout': 310,
             'queue_name_prefix': NOTIFICATION_QUEUE_PREFIX,
+            'is_secure': True,
             'wait_time_seconds': 20  # enable long polling, with a wait time of 20 seconds
         },
         'timezone': 'Europe/London',


### PR DESCRIPTION
Use the new SQS endpoints which will allow us to use VPC endpoints in ECS.

This matches what we do in https://github.com/alphagov/notifications-api/pull/3787



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
