### PR TITLE
Tag releases for Sentry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 
 .PHONY: generate-version-file
 generate-version-file:
-	@echo -e "__commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
+	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
 bootstrap:

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ generate-version-file:
 	@echo -e "__git_commit__ = \"${GIT_COMMIT}\"\n__time__ = \"${DATE}\"" > ${APP_VERSION_FILE}
 
 .PHONY: bootstrap
-bootstrap:
+bootstrap: generate-version-file
 	pip install -r requirements_for_test.txt
 
 .PHONY: freeze-requirements
@@ -44,7 +44,7 @@ freeze-requirements: ## create static requirements.txt
 # ---- DOCKER COMMANDS ---- #
 
 .PHONY: bootstrap-with-docker
-bootstrap-with-docker: ## Setup environment to run app commands
+bootstrap-with-docker: generate-version-file # Setup environment to run app commands
 	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
 
 .PHONY: run-celery-with-docker

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,1 @@
+version.py

--- a/app/performance.py
+++ b/app/performance.py
@@ -27,9 +27,9 @@ def init_performance_monitoring():
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
         try:
-            from app.version import __commit__
+            from app.version import __git_commit__
 
-            release = __commit__
+            release = __git_commit__
         except ImportError:
             release = None
 

--- a/app/performance.py
+++ b/app/performance.py
@@ -26,6 +26,13 @@ def init_performance_monitoring():
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 
+        try:
+            from app.version import __commit__
+
+            release = __commit__
+        except ImportError:
+            release = None
+
         sentry_sdk.init(
             dsn=sentry_dsn,
             environment=environment,
@@ -33,4 +40,5 @@ def init_performance_monitoring():
             send_default_pii=send_pii,
             request_bodies=send_request_bodies,
             traces_sampler=traces_sampler,
+            release=release,
         )

--- a/app/version.py
+++ b/app/version.py
@@ -1,2 +1,0 @@
-__commit__ = "fake-local-dev-sha"
-__time__ = "2022-03-15T12:55:24"


### PR DESCRIPTION
Send the current git commit as a release version to sentry when initialised, which will let us track when errors are introduced and mark errors resolved as of a specific commit/release.

Renames the variable from `__commit__` to `__git_commit__` to match the other apps. I can't see anywhere this is used for antivirus currently, so it shouldn't break anything.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
