### PR TITLE
Created entrypoint for antivirus celery worker

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -eu
+
+case "$@" in
+  web)
+    gunicorn --error-logfile - -c /home/vcap/app/gunicorn_config.py wsgi
+    ;;
+  worker)
+    celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 --uid=`id -u celeryuser`
+    ;;
+  *)
+    echo "Running custom command"
+    $@
+    ;;
+esac
+
+clamd


### PR DESCRIPTION
This entrypoint will allow the antivirus celery worker to initiate and have clamd working .

Maybe we do not need the "web" case.

This PR need to be approved before the PR for the creation of the antivirus celery worker, otherwiose the service will fail by lack of this entrypoint.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
