### PR TITLE
Set SERVER_NAME for local dev

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -53,6 +53,8 @@ class Config(object):
 
 
 class Development(Config):
+    SERVER_NAME = os.getenv("SERVER_NAME")
+
     NOTIFICATION_QUEUE_PREFIX = "development"
     DEBUG = True
     STATSD_ENABLED = False


### PR DESCRIPTION
Adding this to all of our apps (for local/dev configuration) so that we can get URLs built on a .localhost domain when running via docker-compose.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
