### PR TITLE
Refactor dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ freeze-requirements: ## create static requirements.txt
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: generate-version-file # Setup environment to run app commands
-	docker build --build-arg BASE_IMAGE=parent -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
+	docker build --build-arg BASE_IMAGE=base -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container
@@ -71,7 +71,7 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=parent --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
 
 # ---- DEPLOYMENT ---- #
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
         make \
         clamav-daemon \
         clamav-freshclam \
-        libcurl4 \
+        libcurl4 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -38,16 +38,17 @@ WORKDIR /home/vcap/app/
 ##### Python Build Image #####################################################
 FROM ${BASE_IMAGE} AS python_build
 
-RUN echo "Install OS dependencies for python app requirements" && apt-get update && \
+RUN echo "Install OS dependencies for python app requirements" && \
+    apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
         build-essential \
         git \
         libcurl4-openssl-dev \
         curl \
-        libssl-dev \
-    && apt-get -y clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/*
+        libssl-dev && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
 COPY requirements.txt .
 
@@ -58,7 +59,10 @@ RUN echo "Installing python requirements" && \
 ##### Production Image #######################################################
 FROM ${BASE_IMAGE} as production
 
-RUN groupadd -r notify && useradd -r -g notify -ms /bin/bash notify && usermod -a -G clamav notify && chown -R notify:notify /home/vcap
+RUN groupadd -r notify && \
+    useradd -r -g notify -ms /bin/bash notify && \
+    usermod -a -G clamav notify && \
+    chown -R notify:notify /home/vcap
 USER notify
 
 COPY --from=python_build --chown=root:root /opt/venv /opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,6 +56,9 @@ RUN echo "Installing python requirements" && \
     python3 -m venv /opt/venv && \
     /opt/venv/bin/pip install -r requirements.txt
 
+COPY . .
+RUN make generate-version-file  # This file gets copied across
+
 ##### Production Image #######################################################
 FROM ${BASE_IMAGE} as production
 
@@ -75,11 +78,7 @@ ENV PATH="/opt/venv/bin:${PATH}"
 COPY --chown=notify:notify app app
 COPY --chown=notify:notify scripts scripts
 COPY --chown=notify:notify application.py run_celery.py gunicorn_config.py Makefile ./
-
-# .git folder used only for make generate-version-file but we don't wish to include it in our final production build
-COPY --chown=notify:notify .git .git
-RUN make generate-version-file
-RUN rm -rf .git
+COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 
 ##### Test Image ##############################################################
 FROM production as test

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,10 @@ COPY app app
 COPY scripts scripts
 COPY application.py run_celery.py gunicorn_config.py Makefile .
 
+# .git folder used only for make generate-version-file but we don't wish to include it in our final production build
+COPY --chown=notify:notify .git .git
 RUN make generate-version-file
+RUN rm -rf .git
 
 ##### Test Image ##############################################################
 FROM production as test
@@ -94,6 +97,4 @@ RUN mkdir -p app
 COPY --chown=notify:notify requirements.txt requirements_for_test.txt ./
 RUN make bootstrap
 
-# Copy from the real world, one dir up (project root) into the environment's current working directory
-# Docker will rebuild from here down every time.
 COPY --chown=notify:notify . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update && \
 
 RUN mkdir /var/run/clamav && \
     chown clamav:clamav /var/run/clamav && \
-    chmod 750 /var/run/clamav
+    chmod 750 /var/run/clamav && \
+    chown clamav:clamav /usr/sbin/clamd && \
+    chmod u+s /usr/sbin/clamd
 
 RUN echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 RUN if [ "$CLAMAV_USE_MIRROR" = "true" ] ; then echo "PrivateMirror ${CLAMAV_MIRROR_URL}" >> /etc/clamav/freshclam.conf ; fi
@@ -65,9 +67,7 @@ FROM ${BASE_IMAGE} as production
 RUN groupadd -r notify && \
     useradd -r -g notify -ms /bin/bash notify && \
     usermod -a -G clamav notify && \
-    chown -R notify:notify /home/vcap && \
-    chown -R clamav:clamav /var/log/clamav && \
-    chmod -R g+rw /var/log/clamav /var/run/clamav  # Allow members of `clamav` group to read/write logs and clam socket
+    chown -R notify:notify /home/vcap
 USER notify
 
 RUN mkdir /home/vcap/logs

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,8 +77,23 @@ RUN make generate-version-file
 ##### Test Image ##############################################################
 FROM production as test
 
-COPY requirements.txt requirements.in ./
+USER root
+RUN chown -R notify:notify /opt/venv
+RUN echo "Install OS dependencies for test build" && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
+USER notify
 
+# Make sure the app/ directory is there so that "make bootstrap" can create app/version.py
+RUN mkdir -p app
+
+# Install dev/test requirements
+COPY --chown=notify:notify requirements.txt requirements_for_test.txt ./
 RUN make bootstrap
 
-COPY . .
+# Copy from the real world, one dir up (project root) into the environment's current working directory
+# Docker will rebuild from here down every time.
+COPY --chown=notify:notify . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,16 +46,8 @@ RUN groupadd -r notify && useradd -r -g notify -ms /bin/bash notify && usermod -
 USER notify
 
 COPY app app
-COPY application.py .
-COPY run_celery.py .
-COPY gunicorn_config.py .
-COPY Makefile .
-
-COPY scripts/run_app.sh scripts/run_app.sh
-COPY scripts/run_celery.sh scripts/run_celery.sh
-COPY scripts/run_app_paas.sh scripts/run_app_paas.sh
-COPY scripts/run_app_ecs.sh scripts/run_app_ecs.sh
-COPY scripts/paas_app_wrapper.sh scripts/paas_app_wrapper.sh
+COPY scripts scripts
+COPY application.py run_celery.py gunicorn_config.py Makefile .
 
 RUN make generate-version-file
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,13 +10,10 @@ RUN apt-get update && \
     apt-get upgrade -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         git \
-        build-essential \
+        make \
         clamav-daemon \
         clamav-freshclam \
-        libcurl4-openssl-dev \
-        curl \
-        libssl-dev \
-    && \
+        libcurl4 \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -36,14 +33,34 @@ RUN rm freshclam.out
 
 WORKDIR /home/vcap/app/
 
+##### Python Build Image #####################################################
+FROM ${BASE_IMAGE} AS python_build
+
+RUN echo "Install OS dependencies for python app requirements" && apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        git \
+        libcurl4-openssl-dev \
+        curl \
+        libssl-dev \
+    && apt-get -y clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/*
+
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+
+RUN echo "Installing python requirements" && \
+    python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install -r requirements.txt
 
 ##### Production Image #######################################################
 FROM ${BASE_IMAGE} as production
 
 RUN groupadd -r notify && useradd -r -g notify -ms /bin/bash notify && usermod -a -G clamav notify && chown -R notify:notify /home/vcap
 USER notify
+
+COPY --from=python_build --chown=root:root /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY app app
 COPY scripts scripts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -68,9 +68,9 @@ USER notify
 COPY --from=python_build --chown=root:root /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 
-COPY app app
-COPY scripts scripts
-COPY application.py run_celery.py gunicorn_config.py Makefile .
+COPY --chown=notify:notify app app
+COPY --chown=notify:notify scripts scripts
+COPY --chown=notify:notify application.py run_celery.py gunicorn_config.py Makefile .
 
 # .git folder used only for make generate-version-file but we don't wish to include it in our final production build
 COPY --chown=notify:notify .git .git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -74,7 +74,7 @@ ENV PATH="/opt/venv/bin:${PATH}"
 
 COPY --chown=notify:notify app app
 COPY --chown=notify:notify scripts scripts
-COPY --chown=notify:notify application.py run_celery.py gunicorn_config.py Makefile .
+COPY --chown=notify:notify application.py run_celery.py gunicorn_config.py Makefile ./
 
 # .git folder used only for make generate-version-file but we don't wish to include it in our final production build
 COPY --chown=notify:notify .git .git

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,9 @@ FROM ${BASE_IMAGE} as production
 RUN groupadd -r notify && \
     useradd -r -g notify -ms /bin/bash notify && \
     usermod -a -G clamav notify && \
-    chown -R notify:notify /home/vcap
+    chown -R notify:notify /home/vcap && \
+    chown -R clamav:clamav /var/log/clamav && \
+    chmod -R g+rw /var/log/clamav /var/run/clamav  # Allow members of `clamav` group to read/write logs and clam socket
 USER notify
 
 COPY --from=python_build --chown=root:root /opt/venv /opt/venv

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-antivirus:base
-FROM python:3.9.9-slim-bullseye as parent
+FROM python:3.9.9-slim-bullseye as base
 
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
 
@@ -39,16 +39,7 @@ WORKDIR /home/vcap/app/
 COPY requirements.txt .
 RUN pip install -r requirements.txt
 
-##### Test Image ##############################################################
-
-FROM ${BASE_IMAGE} as test
-
-COPY . .
-
-RUN make bootstrap
-
 ##### Production Image #######################################################
-
 FROM ${BASE_IMAGE} as production
 
 RUN useradd -ms /bin/bash celeryuser && usermod -a -G clamav celeryuser
@@ -66,3 +57,12 @@ COPY scripts/run_app_ecs.sh scripts/run_app_ecs.sh
 COPY scripts/paas_app_wrapper.sh scripts/paas_app_wrapper.sh
 
 RUN make generate-version-file
+
+##### Test Image ##############################################################
+FROM production as test
+
+COPY requirements.txt requirements.in ./
+
+RUN make bootstrap
+
+COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -67,6 +67,8 @@ RUN groupadd -r notify && \
     chmod -R g+rw /var/log/clamav /var/run/clamav  # Allow members of `clamav` group to read/write logs and clam socket
 USER notify
 
+RUN mkdir /home/vcap/logs
+
 COPY --from=python_build --chown=root:root /opt/venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,13 +2,15 @@ ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-antivirus:base
 FROM python:3.9.9-slim-bullseye as base
 
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Use clamav database from private mirror. Disable with: --build-arg CLAMAV_USE_MIRROR=false for local builds
 ARG CLAMAV_USE_MIRROR=true
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
+    apt-get install --no-install-recommends -y \
         git \
         make \
         clamav-daemon \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,8 @@ RUN pip install -r requirements.txt
 ##### Production Image #######################################################
 FROM ${BASE_IMAGE} as production
 
-RUN useradd -ms /bin/bash celeryuser && usermod -a -G clamav celeryuser
+RUN groupadd -r notify && useradd -r -g notify -ms /bin/bash notify && usermod -a -G clamav notify && chown -R notify:notify /home/vcap
+USER notify
 
 COPY app app
 COPY application.py .

--- a/scripts/paas_app_wrapper.sh
+++ b/scripts/paas_app_wrapper.sh
@@ -5,7 +5,7 @@ case $NOTIFY_APP_NAME in
     ./scripts/run_app_paas.sh gunicorn -c gunicorn_config.py application
     ;;
   notify-antivirus)
-    ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 --uid=`id -u celeryuser` 2> /dev/null
+    ./scripts/run_app_paas.sh celery -A run_celery.notify_celery worker --loglevel=INFO --concurrency=4 2> /dev/null
     ;;
   *)
     echo "Unknown notify_app_name $NOTIFY_APP_NAME"

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -9,7 +9,7 @@ docker run -it --rm \
   -e FLASK_DEBUG=1 \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$(aws configure get aws_access_key_id)} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$(aws configure get aws_secret_access_key)} \
-  -e NOTIFY_LOG_PATH=/var/log/notify/antivirus \
+  -e NOTIFY_LOG_PATH=/home/vcap/logs \
   -e NOTIFICATION_QUEUE_PREFIX=${NOTIFICATION_QUEUE_PREFIX} \
   -e SENTRY_ENABLED=${SENTRY_ENABLED:-0} \
   -e SENTRY_DSN=${SENTRY_DSN:-} \


### PR DESCRIPTION
Makes the dockerfile consistent with the template-preview dockerfile:

* Adds and uses a `notify` user.
  * There is some custom additional config here where we add the `notify` user to the `clamav` group and update some unix directory permissions to allow read/write by the `clamav` group. When the app used to run as the `clamav` user directly this wasn't needed. Should we deviate here and just run everything as the `clamav` user so we don't need to grant permissions manually?
* Adds a `python_build` step for installing python deps and then copy across the built venv to the production image.
* Store logs in a consistent place (`/home/vcap/logs` rather than `/var/log/notify/antivirus`). This only seems to be for local development.
* Derive the `test` step from the `production` step.

I've manually built+deployed this on preview (both the app and celery versions) and run antivirus functional tests with a ✅ 

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
