### PR TITLE
Change base image from bullseye to bookworm

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-antivirus:base
-FROM python:3.9.9-slim-bullseye as base
+FROM python:3.9.18-slim-bookworm as base
 
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
We are replacing the previous version of the base image from 3.9.9-slim-bullseye to 3.9.18-slim-bookworm



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
