### PR TITLE
Make antivirus-api run 2 instances

### DIFF
--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -2,7 +2,7 @@
 
 applications:
   - name: notify-antivirus-api
-
+    instances: 2
     memory: 4G
     disk_quota: 2G
 


### PR DESCRIPTION
I spotted that the antivirus-api is currently running on 1 instance in production. This means that if the instance crashes, we can't serve requests until the next one starts up. We've seen that happen today in prod.

I think this is on 1 instance at the moment because we don't define how many instances in code anywhere. When we accidentally deleted all our production apps a couple of months ago, we redeployed this app and I think it has been on 1 instance since. I have no idea how many instances it was on before.

I've picked 2 instance because it is more than 1 and will handle the case of a single instance crashing. Equally, our graphs for the app look OK in production. Memory and CPU are good. Request times could maybe be better (90% percentile getting over 1 second) but that might be linked to scanning file size so not sure if it is an indicator of underprovisioning.

Let us try 2 instances and see if that fixes the problem. We can increase it further if we need to.

This will be 2 instances in preview, staging and prod. I think that is OK, maybe overscaled in preview, but I think lets get it fixed and worry about the money after we migrate off the PaaS.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
