### PR TITLE
Bump instance count to 3

### DIFF
--- a/manifest-api.yml.j2
+++ b/manifest-api.yml.j2
@@ -2,7 +2,7 @@
 
 applications:
   - name: notify-antivirus-api
-    instances: 2
+    instances: 3
     memory: 4G
     disk_quota: 2G
 


### PR DESCRIPTION
We had an outage recently due to PaaS rolling our antivirus instances without waiting for a replacement to come up.

This is not a fix, but would give paas more time to perform the roll successfully before potentially causing an outage for us.

The exact cause of the incident is unknown but may be down to slow docker image pull times from github during the app rolling.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
