### PR TITLE
Adds curl to the base image for use in healthcheck

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,9 @@ RUN apt-get update && \
         make \
         clamav-daemon \
         clamav-freshclam \
-        libcurl4 && \
-    apt-get clean && \
+        libcurl4 \
+        curl \ 
+        && apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /var/run/clamav && \
@@ -47,7 +48,6 @@ RUN echo "Install OS dependencies for python app requirements" && \
         build-essential \
         git \
         libcurl4-openssl-dev \
-        curl \
         libssl-dev && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*


### PR DESCRIPTION
This adds curl to the base image to make healthchecks work
---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
