### PR TITLE
notifications-utils: 73.1.0 -> 74.4.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ gunicorn==20.1.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@73.1.0
+git+https://github.com/alphagov/notifications-utils.git@74.4.0
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,6 @@ celery[sqs]==5.2.6
     #   sentry-sdk
 certifi==2023.7.22
     # via
-    #   pyproj
     #   requests
     #   sentry-sdk
 charset-normalizer==2.0.7
@@ -70,8 +69,6 @@ flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-geojson==2.5.0
-    # via notifications-utils
 govuk-bank-holidays==0.10
     # via notifications-utils
 gunicorn==20.1.0
@@ -102,9 +99,9 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@73.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
     # via -r requirements.in
-orderedset==2.0.3
+ordered-set==4.1.0
     # via notifications-utils
 phonenumbers==8.13.26
     # via notifications-utils
@@ -115,8 +112,6 @@ pyasn1==0.4.8
 pycurl==7.44.1
     # via kombu
 pypdf==3.17.1
-    # via notifications-utils
-pyproj==3.6.0
     # via notifications-utils
 python-dateutil==2.8.2
     # via
@@ -149,8 +144,6 @@ segno==1.6.0
     # via notifications-utils
 sentry-sdk[celery,flask]==1.21.1
     # via -r requirements.in
-shapely==1.8.0
-    # via notifications-utils
 six==1.16.0
     # via
     #   awscli-cwlogs


### PR DESCRIPTION
https://github.com/alphagov/notifications-utils/compare/73.1.0...74.4.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
