### PR TITLE
notifications-utils: 74.4.0 -> 74.6.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ gunicorn==20.1.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@74.4.0
+git+https://github.com/alphagov/notifications-utils.git@74.6.0
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.4.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.6.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
https://trello.com/c/n4FmWuff/585-annotate-logs-with-cloudfront-http-request-ids

Replaces  #135

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
