### PR TITLE
manifest generation: handle celery `-ecs-fixup` suffixed app

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GIT_COMMIT ?= $(shell git rev-parse HEAD)
 NOTIFY_CREDENTIALS ?= ~/.notify-credentials
 
 CF_APP ?= notify-antivirus
-CF_MANIFEST_TEMPLATE_PATH ?= manifest$(subst notify-antivirus,,${CF_APP}).yml.j2
+CF_MANIFEST_TEMPLATE_PATH ?= manifest$(subst -ecs-fixup,,$(subst notify-antivirus,,${CF_APP})).yml.j2
 CF_MANIFEST_PATH ?= /tmp/manifest.yml
 
 CF_API ?= api.cloud.service.gov.uk
@@ -105,7 +105,9 @@ generate-manifest:
 	$(if ${GPG_PASSPHRASE_TXT}, $(eval export DECRYPT_CMD=echo -n $$$${GPG_PASSPHRASE_TXT} | ${GPG} --quiet --batch --passphrase-fd 0 --pinentry-mode loopback -d), $(eval export DECRYPT_CMD=${GPG} --quiet --batch -d))
 
 	@jinja2 --strict ${CF_MANIFEST_TEMPLATE_PATH} \
-	    -D environment=${CF_SPACE} --format=yaml \
+	    -D environment=${CF_SPACE} \
+	    -D CF_APP=${CF_APP} \
+	    --format=yaml \
 	    <(${DECRYPT_CMD} ${NOTIFY_CREDENTIALS}/credentials/${CF_SPACE}/paas/environment-variables.gpg) 2>&1
 
 .PHONY: cf-deploy

--- a/manifest.yml.j2
+++ b/manifest.yml.j2
@@ -1,13 +1,33 @@
+{%- set app_vars = {
+  'notify-antivirus': {},
+  'notify-antivirus-ecs-fixup': {
+    'additional_env_vars': {
+      'NOTIFICATION_QUEUE_PREFIX': ('production-' if environment == 'production' else (NOTIFICATION_QUEUE_PREFIX + '-ecs')),
+    },
+    'instances': {
+      'preview': 0,
+      'staging': 0,
+      'production': 0,
+    },
+  },
+} -%}
+
+{%- set app = app_vars[CF_APP] -%}
+{%- set instance_count = app.get('instances', {}).get(environment) -%}
 ---
 
 applications:
-  - name: notify-antivirus
+  - name: {{ CF_APP }}
+
+    {% if instance_count is not none %}
+    instances: {{ instance_count }}
+    {%- endif %}
 
     memory: 4G
     disk_quota: 2G
     health-check-type: process
     routes:
-      - route: notify-antivirus-celery-{{ environment }}.cloudapps.digital
+      - route: {{ CF_APP }}-celery-{{ environment }}.cloudapps.digital
 
     services:
       - logit-ssl-syslog-drain
@@ -15,7 +35,7 @@ applications:
     command: ./scripts/paas_app_wrapper.sh
 
     env:
-      NOTIFY_APP_NAME: notify-antivirus
+      NOTIFY_APP_NAME: {{ CF_APP }}
       CW_APP_NAME: antivirus
       STATSD_HOST: 'notify-statsd-exporter-{{ environment }}.apps.internal'
       NOTIFY_LOG_PATH: /home/vcap/logs/app.log
@@ -30,3 +50,7 @@ applications:
       SENTRY_DSN: '{{ NOTIFICATIONS_ANTIVIRUS_SENTRY_DSN }}'
       SENTRY_ERRORS_SAMPLE_RATE: '{{ NOTIFICATIONS_ANTIVIRUS_SENTRY_ERRORS_SAMPLE_RATE }}'
       SENTRY_TRACES_SAMPLE_RATE: '{{ NOTIFICATIONS_ANTIVIRUS_SENTRY_TRACES_SAMPLE_RATE }}'
+
+      {% for key, value in app.get('additional_env_vars', {}).items() %}
+      {{key}}: '{{value}}'
+      {% endfor %}


### PR DESCRIPTION
https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa

Apply the same mechanism for generating more than one app's manifest from a single template as in the api's manifest template (adapted in https://github.com/alphagov/notifications-api/pull/4002 and https://github.com/alphagov/notifications-api/pull/4012)



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
