### PR TITLE
cf-deploy make target: don't use `--strategy=rolling` with `--no-start`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ cf-deploy: ## Deploys the app to Cloud Foundry
 	grep -E '^\s*instances:' ${CF_MANIFEST_PATH} | tail -n 1 | grep -xE '\s*instances:\s*0+\s*' && touch ${ZERO_DESIRED_INSTANCES_PATH} || true
 
 	# fails after 5 mins if deploy doesn't work
-	cf push ${CF_APP} --strategy=rolling -f ${CF_MANIFEST_PATH} --docker-image ${DOCKER_IMAGE_NAME} --docker-username ${DOCKER_USER_NAME} $$([ -e ${ZERO_DESIRED_INSTANCES_PATH} ] && echo '--no-start')
+	cf push ${CF_APP} -f ${CF_MANIFEST_PATH} --docker-image ${DOCKER_IMAGE_NAME} --docker-username ${DOCKER_USER_NAME} $$([ -e ${ZERO_DESIRED_INSTANCES_PATH} ] && echo '--no-start' || echo '--strategy=rolling')
 	rm -f ${CF_MANIFEST_PATH}
 
 .PHONY: cf-rollback


### PR DESCRIPTION
https://trello.com/c/TSJ74HqV/533-create-a-deployment-in-paas-of-the-workers-that-is-scaled-down-to-0-which-has-the-queue-prefix-for-ecs-production-instead-of-paa

`--strategy=rolling` and `--no-start` are mutually exclusive and `cf` wants us to acknowledge it.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
