### PR TITLE
config: set `NOTIFY_RUNTIME_PLATFORM` and `NOTIFY_REQUEST_LOG_LEVEL`

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,9 @@ class Config(object):
     DEBUG = False
     LOGGING_STDOUT_JSON = os.getenv("LOGGING_STDOUT_JSON") == "1"
 
+    NOTIFY_RUNTIME_PLATFORM = os.getenv("NOTIFY_RUNTIME_PLATFORM", "paas")
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
+
     ###########################
     # Default config values ###
     ###########################


### PR DESCRIPTION
For some reason this was never set for this app, so on PaaS the app just has an empty value.

This configuration should continue to produce `app.request` post-request log messages on PaaS.

See also https://github.com/alphagov/notifications-api/pull/4016



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
