### PR TITLE
notifications-utils: 74.8.0 -> 74.12.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,6 @@ gunicorn==20.1.0
 # PaaS
 awscli-cwlogs==1.4.6
 
-git+https://github.com/alphagov/notifications-utils.git@74.8.0
+git+https://github.com/alphagov/notifications-utils.git@74.12.2
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ cachetools==4.2.4
 celery[sqs]==5.2.6
     # via
     #   -r requirements.in
-    #   celery
     #   sentry-sdk
 certifi==2023.7.22
     # via
@@ -96,7 +95,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.8.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@74.12.2
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils


### PR DESCRIPTION
Bump utils for logging improvements.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
