### PR TITLE
Add requirements to test Dockerfile build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,10 @@ RUN chown -R notify:notify /opt/venv
 RUN echo "Install OS dependencies for test build" && \
     apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends git && \
+    apt-get install -y --no-install-recommends \
+    git \
+    libcurl4-openssl-dev \
+    libssl-dev && \
     apt-get -y clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 USER notify


### PR DESCRIPTION
This adds `libcurl4-openssl-dev` and `libssl-dev` to the test stage of the Dockerfile so that `make freeze-requirements` can be run with Docker.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
