### PR TITLE
remove use of `NOTIFY_RUNTIME_PLATFORM` & `NOTIFY_LOG_PATH` flask config parameters

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -25,7 +25,6 @@ class Config(object):
 
     NOTIFY_APP_NAME = "antivirus"
     AWS_REGION = os.getenv("AWS_REGION", "eu-west-1")
-    NOTIFY_LOG_PATH = os.getenv("NOTIFY_LOG_PATH")
 
     ANTIVIRUS_API_KEY = os.getenv("ANTIVIRUS_API_KEY")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,5 +2,4 @@
 testpaths = tests
 env =
     NOTIFY_ENVIRONMENT=test
-    NOTIFY_LOG_PATH=application.log
     NOTIFICATION_QUEUE_PREFIX=testing

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,6 @@ celery[sqs]==5.2.6
 Flask-HTTPAuth==4.8.0
 gunicorn==20.1.0
 
-git+https://github.com/alphagov/notifications-utils.git@75.1.1
+git+https://github.com/alphagov/notifications-utils.git@76.0.0
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@75.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@76.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/scripts/run_with_docker.sh
+++ b/scripts/run_with_docker.sh
@@ -9,7 +9,6 @@ docker run -it --rm \
   -e FLASK_DEBUG=1 \
   -e AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-$(aws configure get aws_access_key_id)} \
   -e AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-$(aws configure get aws_secret_access_key)} \
-  -e NOTIFY_LOG_PATH=/home/vcap/logs \
   -e NOTIFICATION_QUEUE_PREFIX=${NOTIFICATION_QUEUE_PREFIX} \
   -e SENTRY_ENABLED=${SENTRY_ENABLED:-0} \
   -e SENTRY_DSN=${SENTRY_DSN:-} \


### PR DESCRIPTION
https://trello.com/c/kuPbusFR/724-check-if-we-should-and-then-remove-notifyruntimeplatform-functionality

Depends on https://github.com/alphagov/notifications-utils/pull/1109 (though actually doesn't technically require it)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
