### PR TITLE
Remove environment knowledge from application

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -15,12 +15,14 @@ statsd_client = StatsdClient()
 def create_app(application):
     setup_commands(application)
 
-    from app.config import configs
+    from app.config import Config, configs
     from app.views import main_blueprint
 
     notify_environment = os.environ["NOTIFY_ENVIRONMENT"]
-
-    application.config.from_object(configs[notify_environment])
+    if notify_environment in configs:
+        application.config.from_object(configs[notify_environment])
+    else:
+        application.config.from_object(Config)
 
     init_app(application)
 

--- a/app/config.py
+++ b/app/config.py
@@ -43,7 +43,7 @@ class Config(object):
         "task_queues": [Queue(QueueNames.ANTIVIRUS, Exchange("default"), routing_key=QueueNames.ANTIVIRUS)],
     }
 
-    LETTERS_SCAN_BUCKET_NAME = None
+    LETTERS_SCAN_BUCKET_NAME = os.environ.get("LETTERS_SCAN_BUCKET_NAME")
 
 
 ######################
@@ -73,22 +73,7 @@ class Test(Config):
     LETTERS_SCAN_BUCKET_NAME = "test-letters-pdf"
 
 
-class Preview(Config):
-    LETTERS_SCAN_BUCKET_NAME = "preview-letters-scan"
-
-
-class Staging(Config):
-    LETTERS_SCAN_BUCKET_NAME = "staging-letters-scan"
-
-
-class Production(Config):
-    LETTERS_SCAN_BUCKET_NAME = "production-letters-scan"
-
-
 configs = {
     "development": Development,
     "test": Test,
-    "preview": Preview,
-    "staging": Staging,
-    "production": Production,
 }

--- a/app/performance.py
+++ b/app/performance.py
@@ -11,7 +11,7 @@ def sentry_sampler(sampling_context, sample_rate: float = 0.0):
 
 def init_performance_monitoring():
     environment = os.getenv("NOTIFY_ENVIRONMENT").lower()
-    not_production = environment in {"development", "preview", "staging"}
+    allow_pii = os.getenv("SENTRY_ALLOW_PII", "0") == "1"
     sentry_enabled = bool(int(os.getenv("SENTRY_ENABLED", "0")))
     sentry_dsn = os.getenv("SENTRY_DSN")
 
@@ -21,8 +21,8 @@ def init_performance_monitoring():
         error_sample_rate = float(os.getenv("SENTRY_ERRORS_SAMPLE_RATE", 0.0))
         trace_sample_rate = float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", 0.0))
 
-        send_pii = True if not_production else False
-        send_request_bodies = "medium" if not_production else "never"
+        send_pii = True if allow_pii else False
+        send_request_bodies = "medium" if allow_pii else "never"
 
         traces_sampler = partial(sentry_sampler, sample_rate=trace_sample_rate)
 


### PR DESCRIPTION
What
----

Environment configuration will be passed in during deployments.

Replace environment name checks with feature flags.

Why
----

We are updating our notify deployment model to allow for many more environments. As such environment settings will be kept in as few places as possible (eventually just one place).

The main benefit of this is to be able to add new environments without having to modify source code

Note
----

This change should not be merged until the deployment configuration has been updated. See [the following pr](https://github.com/alphagov/notifications-aws/pull/2209)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
