### PR TITLE
Dockerfile: remove git from base image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ ARG CLAMAV_USE_MIRROR=true
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install --no-install-recommends -y \
-        git \
         make \
         clamav-daemon \
         clamav-freshclam \


### PR DESCRIPTION
This ends up in the final image and I'm not sure we actually need it. Removing it would get rid of one "critical vulnerability" from our reports.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
