### PR TITLE
config: set `NOTIFY_REQUEST_LOG_LEVEL` to INFO

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -26,6 +26,8 @@ class Config(object):
     NOTIFY_APP_NAME = "antivirus"
     AWS_REGION = os.getenv("AWS_REGION", "eu-west-1")
 
+    NOTIFY_REQUEST_LOG_LEVEL = os.getenv("NOTIFY_REQUEST_LOG_LEVEL", "INFO")
+
     ANTIVIRUS_API_KEY = os.getenv("ANTIVIRUS_API_KEY")
 
     CELERY = {


### PR DESCRIPTION
So we actually get request logs..

Otherwise `NOTIFY_REQUEST_LOG_LEVEL` defaults to `CRITICAL` (I was asked to do this because at the time we still had PaaS request logs)

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
