### PR TITLE
Bump utils to 79.0.0

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -6,7 +6,7 @@ from flask import current_app
 def list_routes():
     """List URLs of all application routes."""
     for rule in sorted(current_app.url_map.iter_rules(), key=lambda r: r.rule):
-        print("{:10} {}".format(", ".join(rule.methods - set(["OPTIONS", "HEAD"])), rule.rule))
+        print("{:10} {}".format(", ".join(rule.methods - {"OPTIONS", "HEAD"}), rule.rule))
 
 
 def setup_commands(application):

--- a/app/config.py
+++ b/app/config.py
@@ -3,12 +3,12 @@ import os
 from kombu import Exchange, Queue
 
 
-class QueueNames(object):
+class QueueNames:
     LETTERS = "letter-tasks"
     ANTIVIRUS = "antivirus-tasks"
 
 
-class Config(object):
+class Config:
     STATSD_ENABLED = True
     STATSD_HOST = os.getenv("STATSD_HOST")
     STATSD_PORT = 8125

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 clamd==1.0.2
-Flask==2.3.2
+Flask==3.0.3
 celery[sqs]==5.2.6
 Flask-HTTPAuth==4.8.0
 gunicorn==20.1.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,15 +14,15 @@ blinker==1.6.2
     # via
     #   flask
     #   sentry-sdk
-boto3==1.28.7
+boto3==1.34.129
     # via
     #   kombu
     #   notifications-utils
-botocore==1.31.7
+botocore==1.34.129
     # via
     #   boto3
     #   s3transfer
-cachetools==4.2.4
+cachetools==5.3.3
     # via notifications-utils
 celery[sqs]==5.2.6
     # via
@@ -49,7 +49,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-flask==2.3.2
+flask==3.0.3
     # via
     #   -r requirements.in
     #   flask-httpauth
@@ -60,7 +60,7 @@ flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-govuk-bank-holidays==0.10
+govuk-bank-holidays==0.14
     # via notifications-utils
 gunicorn==20.1.0
     # via
@@ -72,7 +72,7 @@ itsdangerous==2.1.2
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.3
+jinja2==3.1.4
     # via
     #   flask
     #   notifications-utils
@@ -88,7 +88,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -102,9 +102,9 @@ pypdf==3.17.1
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.2
+python-json-logger==2.0.7
     # via notifications-utils
-pytz==2021.3
+pytz==2024.1
     # via
     #   celery
     #   notifications-utils
@@ -116,21 +116,19 @@ requests==2.32.2
     # via
     #   govuk-bank-holidays
     #   notifications-utils
-s3transfer==0.6.1
+s3transfer==0.10.1
     # via boto3
 segno==1.6.0
     # via notifications-utils
 sentry-sdk[celery,flask]==1.21.1
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via
     #   click-repl
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils
-statsd==3.3.0
+statsd==4.0.1
     # via notifications-utils
 urllib3==1.26.18
     # via
@@ -145,7 +143,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==2.3.3
+werkzeug==3.0.3
     # via flask
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
 ## 79.0.0

* Switches on Pyupgrade and a bunch of other more opinionated linting rules

 ## 78.2.0

* Bumped minimum versions of select subdependencies

 ## 78.1.0

* Restrict postcodes to valid UK postcode zones

 ## 78.0.0

* BREAKING CHANGE: recipient validation code has all been moved into separate files in a shared folder. Functionality is unchanged.
  - Email address validation can be found in `notifications_utils.recipient_validation.email_address`
  - Phone number validation can be found in `notifications_utils.recipient_validation.phone_number`
  - Postal address validation can be found in `notifications_utils.recipient_validation.postal_address`
* BREAKING CHANGE: InvalidPhoneError and InvalidAddressError no longer extend InvalidEmailError.
  - if you wish to handle all recipient validation errors, please use `notifications_utils.recipient_validation.errors.InvalidRecipientError`

 ## 77.2.1

* Change redis delete behaviour to error, rather than end up with stale data, if Redis is unavailable.

 ## 77.2.0

* `NotifyTask`: include pid and other structured fields in completion log messages

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/77.1.1...79.0.0

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
