### PR TITLE
Revert "Bump utils to 79.0.0"

### DIFF
--- a/app/commands.py
+++ b/app/commands.py
@@ -6,7 +6,7 @@ from flask import current_app
 def list_routes():
     """List URLs of all application routes."""
     for rule in sorted(current_app.url_map.iter_rules(), key=lambda r: r.rule):
-        print("{:10} {}".format(", ".join(rule.methods - {"OPTIONS", "HEAD"}), rule.rule))
+        print("{:10} {}".format(", ".join(rule.methods - set(["OPTIONS", "HEAD"])), rule.rule))
 
 
 def setup_commands(application):

--- a/app/config.py
+++ b/app/config.py
@@ -3,12 +3,12 @@ import os
 from kombu import Exchange, Queue
 
 
-class QueueNames:
+class QueueNames(object):
     LETTERS = "letter-tasks"
     ANTIVIRUS = "antivirus-tasks"
 
 
-class Config:
+class Config(object):
     STATSD_ENABLED = True
     STATSD_HOST = os.getenv("STATSD_HOST")
     STATSD_PORT = 8125

--- a/requirements.in
+++ b/requirements.in
@@ -1,9 +1,9 @@
 clamd==1.0.2
-Flask==3.0.3
+Flask==2.3.2
 celery[sqs]==5.2.6
 Flask-HTTPAuth==4.8.0
 gunicorn==20.1.0
 
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
 
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,15 +14,15 @@ blinker==1.6.2
     # via
     #   flask
     #   sentry-sdk
-boto3==1.34.129
+boto3==1.28.7
     # via
     #   kombu
     #   notifications-utils
-botocore==1.34.129
+botocore==1.31.7
     # via
     #   boto3
     #   s3transfer
-cachetools==5.3.3
+cachetools==4.2.4
     # via notifications-utils
 celery[sqs]==5.2.6
     # via
@@ -49,7 +49,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-flask==3.0.3
+flask==2.3.2
     # via
     #   -r requirements.in
     #   flask-httpauth
@@ -60,7 +60,7 @@ flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
-govuk-bank-holidays==0.14
+govuk-bank-holidays==0.10
     # via notifications-utils
 gunicorn==20.1.0
     # via
@@ -72,7 +72,7 @@ itsdangerous==2.1.2
     # via
     #   flask
     #   notifications-utils
-jinja2==3.1.4
+jinja2==3.1.3
     # via
     #   flask
     #   notifications-utils
@@ -88,7 +88,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@79.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -102,9 +102,9 @@ pypdf==3.17.1
     # via notifications-utils
 python-dateutil==2.8.2
     # via botocore
-python-json-logger==2.0.7
+python-json-logger==2.0.2
     # via notifications-utils
-pytz==2024.1
+pytz==2021.3
     # via
     #   celery
     #   notifications-utils
@@ -116,19 +116,21 @@ requests==2.32.2
     # via
     #   govuk-bank-holidays
     #   notifications-utils
-s3transfer==0.10.1
+s3transfer==0.6.1
     # via boto3
 segno==1.6.0
     # via notifications-utils
 sentry-sdk[celery,flask]==1.21.1
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   sentry-sdk
 six==1.16.0
     # via
     #   click-repl
     #   python-dateutil
 smartypants==2.0.1
     # via notifications-utils
-statsd==4.0.1
+statsd==3.3.0
     # via notifications-utils
 urllib3==1.26.18
     # via
@@ -143,7 +145,7 @@ vine==5.0.0
     #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
-werkzeug==3.0.3
+werkzeug==2.3.3
     # via flask
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
Reverts alphagov/notifications-antivirus#163

We’re seeing failing functional tests on preview and want to see if this helps