### PR TITLE
Dockerfile: pre-compile bytecode for app in production image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,6 +79,8 @@ COPY --chown=notify:notify scripts scripts
 COPY --chown=notify:notify application.py run_celery.py gunicorn_config.py Makefile ./
 COPY --from=python_build --chown=notify:notify /home/vcap/app/app/version.py app/version.py
 
+RUN python -m compileall .
+
 ##### Test Image ##############################################################
 FROM production as test
 


### PR DESCRIPTION
This should produce a small improvement in startup time. Bytecode for the libraries in the venv is already generated during pip install.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
