### PR TITLE
Add notify environment config variable

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,10 @@ class Config(object):
     STATSD_HOST = os.getenv("STATSD_HOST")
     STATSD_PORT = 8125
 
+    # The config option NOTIFY_ENVIRONMENT is purely used for logging.
+    # It should not be used for any logical conditionals in the code.
+    NOTIFY_ENVIRONMENT = os.environ["NOTIFY_ENVIRONMENT"]
+
     NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")
 
     # Logging


### PR DESCRIPTION
What
----

Add notify-environment config for logging

Why
----

This is for logging purposes which will be included when notifications-utils is bumped to the latest version.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
