### PR TITLE
Change port mapping to use the loopback address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ run-celery-with-docker: ## Run celery in Docker container
 
 .PHONY: run-flask-with-docker
 run-flask-with-docker: ## Run flask in Docker container
-	export DOCKER_ARGS="-p 6016:6016" && ./scripts/run_with_docker.sh ./scripts/run_app.sh
+	export DOCKER_ARGS="-p 127.0.0.1:6016:6016" && ./scripts/run_with_docker.sh ./scripts/run_app.sh
 
 .PHONY: test
 test: ## Run tests (used by Concourse)


### PR DESCRIPTION
Docker defaults to using `0.0.0.0`, the default route listening on all network interfaces, as opposed to the loopback address (`127.0.0.1`). This has security implications and we have been asked to change it.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
