### PR TITLE
add gds-metrics

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -2,6 +2,7 @@ import os
 import time
 
 from flask import g, jsonify, request
+from gds_metrics import GDSMetrics
 from notifications_utils import logging, request_helper
 from notifications_utils.celery import NotifyCelery
 from notifications_utils.clients.statsd.statsd_client import StatsdClient
@@ -10,6 +11,7 @@ from app.commands import setup_commands
 
 notify_celery = NotifyCelery()
 statsd_client = StatsdClient()
+metrics = GDSMetrics()
 
 
 def create_app(application):
@@ -25,6 +27,9 @@ def create_app(application):
         application.config.from_object(Config)
 
     init_app(application)
+
+    # Metrics intentionally high up to give the most accurate timing and reliability that the metric is recorded
+    metrics.init_app(application)
 
     statsd_client.init_app(application)
     logging.init_app(application, statsd_client)

--- a/requirements.in
+++ b/requirements.in
@@ -7,4 +7,8 @@ gunicorn==20.1.0
 # Run `make bump-utils` to update to the latest version
 notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@77.1.1
 
+# gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
+prometheus-client==0.15.0
+git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
+
 sentry_sdk[flask,celery]>=1.0.0,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ billiard==3.6.4.0
 blinker==1.6.2
     # via
     #   flask
+    #   gds-metrics
     #   sentry-sdk
 boto3==1.28.7
     # via
@@ -54,12 +55,15 @@ flask==2.3.2
     #   -r requirements.in
     #   flask-httpauth
     #   flask-redis
+    #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
 flask-httpauth==4.8.0
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils
+gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
+    # via -r requirements.in
 govuk-bank-holidays==0.10
     # via notifications-utils
 gunicorn==20.1.0
@@ -94,6 +98,10 @@ ordered-set==4.1.0
     # via notifications-utils
 phonenumbers==8.13.26
     # via notifications-utils
+prometheus-client==0.15.0
+    # via
+    #   -r requirements.in
+    #   gds-metrics
 prompt-toolkit==3.0.24
     # via click-repl
 pycurl==7.44.1
@@ -121,9 +129,7 @@ s3transfer==0.6.1
 segno==1.6.0
     # via notifications-utils
 sentry-sdk[celery,flask]==1.21.1
-    # via
-    #   -r requirements.in
-    #   sentry-sdk
+    # via -r requirements.in
 six==1.16.0
     # via
     #   click-repl


### PR DESCRIPTION
As absurd as it may be to add yet another way of reporting metrics, this allows us to gather flask metrics via the prometheus protocol like other apps and show them in the recently-added "flask requests" dashboard.

Has been tested by deploying with https://github.com/alphagov/notifications-aws/pull/2347 to a dev environment where the cluster's internal prometheus was queried via an ecs-exec session.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
