### PR TITLE
Stop Docker builds from being based on an 8mo old image by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ bump-utils:  # Bump notifications-utils package to latest version
 
 .PHONY: bootstrap-with-docker
 bootstrap-with-docker: generate-version-file # Setup environment to run app commands
-	docker build --build-arg BASE_IMAGE=base -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
+	docker build -f docker/Dockerfile --target test -t notifications-antivirus --build-arg CLAMAV_USE_MIRROR=false .
 
 .PHONY: run-celery-with-docker
 run-celery-with-docker: ## Run celery in Docker container
@@ -68,4 +68,4 @@ upload-to-docker-registry: ## Upload the current version of the docker image to 
 	$(if ${DOCKER_USER_NAME},,$(error Must specify DOCKER_USER_NAME))
 	$(if ${CF_DOCKER_PASSWORD},,$(error Must specify CF_DOCKER_PASSWORD))
 	@docker login ${DOCKER_IMAGE} -u ${DOCKER_USER_NAME} -p ${CF_DOCKER_PASSWORD}
-	docker buildx build --build-arg BASE_IMAGE=base --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .
+	docker buildx build --platform linux/amd64 --push -f docker/Dockerfile -t ${DOCKER_IMAGE_NAME} .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,3 @@
-ARG BASE_IMAGE=ghcr.io/alphagov/notify/notifications-antivirus:base
 FROM python:3.11-slim-bookworm as base
 
 ENV CLAMAV_MIRROR_URL https://s3.eu-west-1.amazonaws.com/notifications.service.gov.uk-clamav-database-mirror/clam
@@ -38,7 +37,7 @@ RUN rm freshclam.out
 WORKDIR /home/vcap/app/
 
 ##### Python Build Image #####################################################
-FROM ${BASE_IMAGE} AS python_build
+FROM base AS python_build
 
 RUN echo "Install OS dependencies for python app requirements" && \
     apt-get update && \
@@ -61,7 +60,7 @@ COPY . .
 RUN make generate-version-file  # This file gets copied across
 
 ##### Production Image #######################################################
-FROM ${BASE_IMAGE} as production
+FROM base as production
 
 RUN groupadd -r notify && \
     useradd -r -g notify -ms /bin/bash notify && \


### PR DESCRIPTION
[Trello card](https://trello.com/c/jzNNwLbO/928-rationalise-the-weird-way-we-handle-base-images-in-our-dockerfiles)

There used to be a Concourse job to build & push the base image to GHCR, but it's long gone and the last push was a long time ago.

I appreciate that this weird setup was probably put in place to speed up image builds, but I don't think it's worth the extra complexity, nor the risk of people accidentally running an unpatched 8 month old image.



---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
