### PR TITLE
Remove pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,0 @@
-
-
----
-
-🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨
-
-For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)


### PR DESCRIPTION
All our apps are continuously deployed now, so we don’t need to  specifically call it out when making PRs against this app.

---

🚨⚠️ This will be deployed automatically all the way to production when you click merge ⚠️🚨

For more information, including how to check this deployment on preview or staging first before it goes to production, see our [team wiki section on deployment](https://github.com/alphagov/notifications-manuals/wiki/Merging-and-deploying#deployment)
