### PR TITLE
Bump Sentry SDK to 1.45.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -10,4 +10,4 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99
 prometheus-client==0.15.0
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 
-sentry_sdk[flask,celery]>=1.0.0,<2.0.0
+sentry_sdk[flask,celery]==1.45.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -93,6 +93,7 @@ kombu==5.3.7
 markupsafe==2.1.2
     # via
     #   jinja2
+    #   sentry-sdk
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
@@ -134,7 +135,7 @@ s3transfer==0.10.2
     # via boto3
 segno==1.6.1
     # via notifications-utils
-sentry-sdk==1.21.1
+sentry-sdk==1.45.1
     # via -r requirements.in
 setuptools==75.6.0
     # via gunicorn

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -231,7 +231,7 @@ segno==1.6.1
     # via
     #   -r requirements.txt
     #   notifications-utils
-sentry-sdk==1.21.1
+sentry-sdk==1.45.1
     # via -r requirements.txt
 setuptools==75.6.0
     # via


### PR DESCRIPTION
Fixes GHSA-g92j-qhmh-64v2

Not something that likely affects us, but clears down another Dependabot warning.

This fix was released in sentry-sdk==2.8.0, then also backported to sentry-sdk==1.45.1.

I think we could probably upgrade to Sentry >= 2 without making any changes, but more testing would be needed to validate this. So just going with the backport for now.

Specifying an exact version because that’s our convention.

***

Matches what we’ve already done in https://github.com/alphagov/notifications-admin/pull/5391 