### PR TITLE
Bump utils to 99.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -9,7 +9,7 @@ repos:
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.9.2'
+  rev: 'v0.11.4'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix]

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ kombu==5.3.7
 Flask-HTTPAuth==4.8.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.1.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.5.1
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ dnspython==2.6.1
     # via eventlet
 eventlet==0.39.1
     # via gunicorn
-flask==3.1.0
+flask==3.1.1
     # via
     #   flask-httpauth
     #   flask-redis
@@ -92,12 +92,13 @@ kombu==5.3.7
     #   celery
 markupsafe==2.1.2
     # via
+    #   flask
     #   jinja2
     #   sentry-sdk
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils
@@ -121,7 +122,7 @@ python-dateutil==2.8.2
     # via
     #   botocore
     #   celery
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via notifications-utils
 pytz==2024.2
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -81,7 +81,7 @@ eventlet==0.39.1
     #   gunicorn
 execnet==2.1.1
     # via pytest-xdist
-flask==3.1.0
+flask==3.1.1
     # via
     #   -r requirements.txt
     #   flask-httpauth
@@ -141,13 +141,14 @@ kombu==5.3.7
 markupsafe==2.1.2
     # via
     #   -r requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
 mistune==0.8.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@84b675433fdd7c17c1eee6e546120aa3a4e5887b
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@d669a9544cc87372a10af8786d3bb172593261fa
     # via -r requirements.txt
 ordered-set==4.1.0
     # via
@@ -199,7 +200,7 @@ python-dateutil==2.8.2
     #   botocore
     #   celery
     #   freezegun
-python-json-logger==2.0.7
+python-json-logger==3.3.0
     # via
     #   -r requirements.txt
     #   notifications-utils
@@ -224,7 +225,7 @@ requests==2.32.3
     #   requests-mock
 requests-mock==1.12.1
     # via -r requirements_for_test_common.in
-ruff==0.9.2
+ruff==0.11.4
     # via -r requirements_for_test_common.in
 s3transfer==0.10.2
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 beautifulsoup4==4.12.3
 pytest==8.3.4
@@ -9,4 +9,4 @@ pytest-testmon==2.1.1
 requests-mock==1.12.1
 freezegun==1.5.1
 
-ruff==0.9.2  # Also update `.pre-commit-config.yaml` if this changes
+ruff==0.11.4  # Also update `.pre-commit-config.yaml` if this changes

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.1.0
+# This file was automatically copied from notifications-utils@99.5.1
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
 ## 99.5.1

* Bump minimum Flask version to 3.1.1

 ## 99.5.0

* Update economy letter transit date to 5 days

 ## 99.4.1

* Fix celery beat logging so that it will log in json

 ## 99.4.0

* Add celery logging configuration for json logging

 ## 99.3.4

* `celery.NotifyTask`: don't emit early log if called synchronously

 ## 99.3.3

* Fix bug with non-SMS templates considering international SMS limits

 ## 99.3.2

* Stops counting Crown Dependency phone numbers in CSV file as international

 ## 99.3.1

* Bump `python-json-logger` to version 3

 ## 99.3.0

* Adds `RecipientCSV.international_sms_count`
* Adds `RecipientCSV.more_international_sms_than_can_send` (initialise per `RecipientCSV(remaining_international_sms_messages=123)` to enable this check)

 ## 99.2.0

* Add s3 multipart upload lifecycle (create, upload, complete, abort)

 ## 99.1.2

* Normalise unusual dashes and spacing characters in phone numbers

 ## 99.1.1

* Bump ruff to latest version

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.1.0...99.5.1