### PR TITLE
Bump utils to 99.8.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ kombu==5.3.7
 Flask-HTTPAuth==4.8.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.6.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@99.8.0
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -98,7 +98,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b6f3cf856d6114a296e2b59de603a213ad46220a
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -148,7 +148,7 @@ mistune==0.8.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b6f3cf856d6114a296e2b59de603a213ad46220a
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@a97b36f6a32e7bb917152c8cd716fe65fa15ac9f
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@99.6.0
+# This file was automatically copied from notifications-utils@99.8.0
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
Just to keep things up to date

 ## 99.8.0

* Add new version of GOV.UK brand to email template, behind a flag

 ## 99.7.0

* Update economy letter transit dates to max 8 days

 ## 99.6.0

* Improve celery json logging. Include beat with separate log level options and testing

 ## 99.5.2

* Make inheritence of annotations on SerialisedModel work on both the class and its instances

***

Complete changes: https://github.com/alphagov/notifications-utils/compare/99.5.1...99.8.0