### PR TITLE
Bump greenlet and pycurl to latest versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 #    uv pip compile requirements.in -o requirements.txt
 amqp==5.3.1
     # via kombu
-async-timeout==4.0.2
-    # via redis
 awscrt==0.20.11
     # via botocore
 billiard==4.2.1
@@ -68,7 +66,7 @@ gds-metrics @ git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6
     # via -r requirements.in
 govuk-bank-holidays==0.15
     # via notifications-utils
-greenlet==3.0.3
+greenlet==3.2.3
     # via eventlet
 gunicorn==23.0.0
     # via notifications-utils
@@ -112,13 +110,13 @@ prometheus-client==0.15.0
     #   gds-metrics
 prompt-toolkit==3.0.24
     # via click-repl
-pycurl==7.44.1
+pycurl==7.45.6
     # via
     #   celery
     #   kombu
 pypdf==3.17.1
     # via notifications-utils
-python-dateutil==2.8.2
+python-dateutil==2.9.0
     # via
     #   botocore
     #   celery

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,10 +4,6 @@ amqp==5.3.1
     # via
     #   -r requirements.txt
     #   kombu
-async-timeout==4.0.2
-    # via
-    #   -r requirements.txt
-    #   redis
 awscrt==0.20.11
     # via
     #   -r requirements.txt
@@ -102,7 +98,7 @@ govuk-bank-holidays==0.15
     # via
     #   -r requirements.txt
     #   notifications-utils
-greenlet==3.0.3
+greenlet==3.2.3
     # via
     #   -r requirements.txt
     #   eventlet
@@ -173,7 +169,7 @@ prompt-toolkit==3.0.24
     # via
     #   -r requirements.txt
     #   click-repl
-pycurl==7.44.1
+pycurl==7.45.6
     # via -r requirements.txt
 pypdf==3.17.1
     # via
@@ -194,7 +190,7 @@ pytest-testmon==2.1.1
     # via -r requirements_for_test_common.in
 pytest-xdist==3.6.1
     # via -r requirements_for_test_common.in
-python-dateutil==2.8.2
+python-dateutil==2.9.0
     # via
     #   -r requirements.txt
     #   botocore


### PR DESCRIPTION
Older versions don’t install on newer versions of Python because of the way they are packaged

Also dateutil because it gives a deprecation warning