### PR TITLE
Upgrade to python 3.13

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim-bookworm as base
+FROM python:3.13-slim-bookworm as base
 
 COPY --from=ghcr.io/astral-sh/uv:0.5.30 /uv /uvx /bin/
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 #    uv pip compile requirements.in -o requirements.txt
 amqp==5.3.1
     # via kombu
-async-timeout==5.0.1
-    # via redis
 awscrt==0.20.11
     # via botocore
 billiard==4.2.1

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -4,10 +4,6 @@ amqp==5.3.1
     # via
     #   -r requirements.txt
     #   kombu
-async-timeout==5.0.1
-    # via
-    #   -r requirements.txt
-    #   redis
 awscrt==0.20.11
     # via
     #   -r requirements.txt


### PR DESCRIPTION
This PR upgrades the Python version to 3.13 from 3.13 as directed in[ this](https://trello.com/c/lCN3U6wV/363-upgrade-notifications-antivirus-to-python-313) card.
More details are available in [this](https://docs.google.com/document/d/150HRwBpG0CqYHkWxkZJWDhrX7AT9v-4eu7NXbQpXpVg/edit?tab=t.0) document, including performance test results. 