### PR TITLE
upgrade celery to v5.5.3 and enable verbose logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@103.0.0
+# This file was automatically copied from notifications-utils@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/config.py
+++ b/app/config.py
@@ -32,8 +32,8 @@ class Config:
     NOTIFY_ENVIRONMENT = os.environ["NOTIFY_ENVIRONMENT"]
 
     # Celery log levels
-    CELERY_WORKER_LOG_LEVEL = os.getenv("CELERY_WORKER_LOG_LEVEL", "CRITICAL").upper()
-    CELERY_BEAT_LOG_LEVEL = os.getenv("CELERY_BEAT_LOG_LEVEL", "INFO").upper()
+    CELERY_WORKER_LOG_LEVEL = os.getenv("CELERY_WORKER_LOG_LEVEL", "DEBUG").upper()
+    CELERY_BEAT_LOG_LEVEL = os.getenv("CELERY_BEAT_LOG_LEVEL", "DEBUG").upper()
 
     NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")
 
@@ -85,7 +85,7 @@ class Config:
 class Development(Config):
     SERVER_NAME = os.getenv("SERVER_NAME")
 
-    CELERY_WORKER_LOG_LEVEL = "INFO"
+    CELERY_WORKER_LOG_LEVEL = "DEBUG"
 
     NOTIFICATION_QUEUE_PREFIX = "development"
     DEBUG = True
@@ -110,7 +110,7 @@ class Test(Config):
 
     ANTIVIRUS_API_KEY = "test-key"
 
-    CELERY_WORKER_LOG_LEVEL = "INFO"
+    CELERY_WORKER_LOG_LEVEL = "DEBUG"
 
     LETTERS_SCAN_BUCKET_NAME = "test-letters-pdf"
 

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 clamd==1.0.2
-celery[sqs]==5.4.0
-kombu==5.3.7
+celery[sqs]==5.5.3
+kombu==5.5.4
 Flask-HTTPAuth==4.8.0
 
 # Run `make bump-utils` to update to the latest version

--- a/requirements.in
+++ b/requirements.in
@@ -4,7 +4,7 @@ kombu==5.5.4
 Flask-HTTPAuth==4.8.0
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@103.0.0
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
 
 # gds-metrics requires prometheseus 0.2.0, override that requirement as later versions bring significant performance gains
 prometheus-client==0.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ botocore==1.34.150
     #   s3transfer
 cachetools==5.5.0
     # via notifications-utils
-celery==5.4.0
+celery==5.5.3
     # via
     #   -r requirements.in
     #   sentry-sdk
@@ -84,7 +84,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-kombu==5.3.7
+kombu==5.5.4
     # via
     #   -r requirements.in
     #   celery
@@ -101,7 +101,9 @@ notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b2
 ordered-set==4.1.0
     # via notifications-utils
 packaging==25.0
-    # via gunicorn
+    # via
+    #   gunicorn
+    #   kombu
 phonenumbers==9.0.10
     # via notifications-utils
 prometheus-client==0.15.0
@@ -110,10 +112,6 @@ prometheus-client==0.15.0
     #   gds-metrics
 prompt-toolkit==3.0.24
     # via click-repl
-pycurl==7.45.6
-    # via
-    #   celery
-    #   kombu
 pypdf==3.17.1
     # via notifications-utils
 python-dateutil==2.9.0
@@ -146,7 +144,7 @@ smartypants==2.0.1
 statsd==4.0.1
     # via notifications-utils
 tzdata==2025.2
-    # via celery
+    # via kombu
 urllib3==1.26.19
     # via
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -96,7 +96,7 @@ markupsafe==2.1.2
     #   werkzeug
 mistune==0.8.4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b2c6b779da8f2da0edc885059f91ca8fb9733913
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
     # via -r requirements.in
 ordered-set==4.1.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -144,7 +144,7 @@ mistune==0.8.4
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b2c6b779da8f2da0edc885059f91ca8fb9733913
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
     # via -r requirements.txt
 ordered-set==4.1.0
     # via

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -32,7 +32,7 @@ cachetools==5.5.0
     # via
     #   -r requirements.txt
     #   notifications-utils
-celery==5.4.0
+celery==5.5.3
     # via -r requirements.txt
 certifi==2024.7.4
     # via
@@ -130,7 +130,7 @@ jmespath==0.10.0
     #   -r requirements.txt
     #   boto3
     #   botocore
-kombu==5.3.7
+kombu==5.5.4
     # via
     #   -r requirements.txt
     #   celery
@@ -154,6 +154,7 @@ packaging==25.0
     # via
     #   -r requirements.txt
     #   gunicorn
+    #   kombu
     #   pytest
 phonenumbers==9.0.10
     # via
@@ -169,8 +170,6 @@ prompt-toolkit==3.0.24
     # via
     #   -r requirements.txt
     #   click-repl
-pycurl==7.45.6
-    # via -r requirements.txt
 pypdf==3.17.1
     # via
     #   -r requirements.txt
@@ -248,7 +247,7 @@ statsd==4.0.1
 tzdata==2025.2
     # via
     #   -r requirements.txt
-    #   celery
+    #   kombu
 urllib3==1.26.19
     # via
     #   -r requirements.txt

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@103.0.0
+# This file was automatically copied from notifications-utils@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
 
 beautifulsoup4==4.12.3
 pytest==8.3.4

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@103.0.0
+# This file was automatically copied from notifications-utils@7772125aec72ccc5651bfd53c0ab1bb9ce6a3efe
 
 extend-exclude = [
     "migrations/versions/",


### PR DESCRIPTION
🚨 Testing out upgrading celery to 5.5.3. Verbose logging is enabled and this will not be merged into main 🚨 