### PR TITLE
feat: add MessageGroupId in queues to activate fair-queue feature

### DIFF
--- a/app/celery/tasks.py
+++ b/app/celery/tasks.py
@@ -31,6 +31,7 @@ def scan_file(self, filename):
             name=task_name,
             kwargs={"filename": filename},
             queue=QueueNames.LETTERS,
+            MessageGroupId=self.message_group_id,
         )
     except (clamd.ClamdError, BotoClientError) as e:
         try:
@@ -45,6 +46,7 @@ def scan_file(self, filename):
                 name="process-virus-scan-error",
                 kwargs={"filename": filename},
                 queue=QueueNames.LETTERS,
+                MessageGroupId=self.message_group_id,
             )
 
 

--- a/app/config.py
+++ b/app/config.py
@@ -36,6 +36,7 @@ class Config:
     CELERY_BEAT_LOG_LEVEL = os.getenv("CELERY_BEAT_LOG_LEVEL", "INFO").upper()
 
     NOTIFICATION_QUEUE_PREFIX = os.getenv("NOTIFICATION_QUEUE_PREFIX")
+    ENABLE_SQS_MESSAGE_GROUP_IDS = os.environ.get("ENABLE_SQS_MESSAGE_GROUP_IDS", "1") == "1"
 
     # Logging
     DEBUG = False

--- a/tests/celery/test_tasks.py
+++ b/tests/celery/test_tasks.py
@@ -1,3 +1,6 @@
+from contextlib import contextmanager
+from unittest.mock import patch
+
 from botocore.exceptions import ClientError as BotoClientError
 from celery.exceptions import MaxRetriesExceededError
 from clamd import ClamdError
@@ -6,6 +9,13 @@ from app.celery.tasks import scan_file
 from app.config import QueueNames
 
 TEST_FILENAME = "EXAMPLE-SCAN-LETTER.pdf"
+TEST_MESSAGE_GROUP_ID = "test-message-group-id"
+
+
+@contextmanager
+def _with_message_group_id(value: str):
+    with patch("notifications_utils.celery.NotifyTask.message_group_id", new=value, create=True):
+        yield
 
 
 def test_scan_no_virus(notify_antivirus, mocker):
@@ -13,12 +23,14 @@ def test_scan_no_virus(notify_antivirus, mocker):
     mocker.patch("app.celery.tasks.clamav_scan", return_value=True)
     mock_send_task = mocker.patch("app.notify_celery.send_task")
 
-    scan_file(TEST_FILENAME)
+    with _with_message_group_id(TEST_MESSAGE_GROUP_ID):
+        scan_file(TEST_FILENAME)
 
     mock_send_task.assert_called_once_with(
         name="sanitise-letter",
         kwargs={"filename": TEST_FILENAME},
         queue=QueueNames.LETTERS,
+        MessageGroupId=TEST_MESSAGE_GROUP_ID,
     )
 
 
@@ -27,12 +39,14 @@ def test_scan_virus_detected(notify_antivirus, mocker, caplog):
     mocker.patch("app.celery.tasks.clamav_scan", return_value=False)
     mock_send_task = mocker.patch("app.notify_celery.send_task")
 
-    scan_file(TEST_FILENAME)
+    with _with_message_group_id(TEST_MESSAGE_GROUP_ID):
+        scan_file(TEST_FILENAME)
 
     mock_send_task.assert_called_once_with(
         name="process-virus-scan-failed",
         kwargs={"filename": TEST_FILENAME},
         queue=QueueNames.LETTERS,
+        MessageGroupId=TEST_MESSAGE_GROUP_ID,
     )
 
     assert "VIRUS FOUND for file: EXAMPLE-SCAN-LETTER.pdf" in caplog.messages
@@ -62,10 +76,12 @@ def test_scan_virus_max_retries(notify_antivirus, mocker):
     mocker.patch("app.celery.tasks.scan_file.retry", side_effect=MaxRetriesExceededError)
     mock_send_task = mocker.patch("app.notify_celery.send_task")
 
-    scan_file(TEST_FILENAME)
+    with _with_message_group_id(TEST_MESSAGE_GROUP_ID):
+        scan_file(TEST_FILENAME)
 
     mock_send_task.assert_called_once_with(
         name="process-virus-scan-error",
         kwargs={"filename": TEST_FILENAME},
         queue=QueueNames.LETTERS,
+        MessageGroupId=TEST_MESSAGE_GROUP_ID,
     )


### PR DESCRIPTION
## Summary

- Passed MessageGroupId (service id) on all relevant queue calls 


### Ticket
[Fair queue notifications-antivirus](https://trello.com/c/ojm1gUZy/1458-fair-queue-antivirus)