### PR TITLE
Pin Github actions to exact SHAs

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -9,6 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - name: 'Checkout Repository'
-       uses: actions/checkout@v5
+       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
      - name: Dependency Review
-       uses: actions/dependency-review-action@v4
+       uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48


### PR DESCRIPTION
To avoid these dependencies being silently upgraded