### PR TITLE
Manually bump Flask-HTTPAuth to 4.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -58,7 +58,7 @@ flask==3.1.3
     #   gds-metrics
     #   notifications-utils
     #   sentry-sdk
-flask-httpauth==4.8.0
+flask-httpauth==4.8.1
     # via -r requirements.in
 flask-redis==0.4.0
     # via notifications-utils

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -84,7 +84,7 @@ flask==3.1.3
     #   flask-redis
     #   gds-metrics
     #   notifications-utils
-flask-httpauth==4.8.0
+flask-httpauth==4.8.1
     # via -r requirements.txt
 flask-redis==0.4.0
     # via


### PR DESCRIPTION
This was meant to happen in https://github.com/alphagov/notifications-antivirus/pull/233

However because 4.8.1 came out 13 days ago it was ignored by the `--exclude-newer 14d` flag.