### PR TITLE
Bump utils to 117.0.1, remove StatsD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@117.0.1
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,13 +5,11 @@ from flask import g, jsonify, request
 from gds_metrics import GDSMetrics
 from notifications_utils import request_helper
 from notifications_utils.celery import NotifyCelery
-from notifications_utils.clients.statsd.statsd_client import StatsdClient
 from notifications_utils.logging import flask as utils_logging
 
 from app.commands import setup_commands
 
 notify_celery = NotifyCelery()
-statsd_client = StatsdClient()
 metrics = GDSMetrics()
 
 
@@ -32,8 +30,7 @@ def create_app(application):
     # Metrics intentionally high up to give the most accurate timing and reliability that the metric is recorded
     metrics.init_app(application)
 
-    statsd_client.init_app(application)
-    utils_logging.init_app(application, statsd_client)
+    utils_logging.init_app(application)
     request_helper.init_app(application)
     notify_celery.init_app(application)
 

--- a/app/config.py
+++ b/app/config.py
@@ -23,10 +23,6 @@ class QueueNames:
 
 
 class Config:
-    STATSD_ENABLED = True
-    STATSD_HOST = os.getenv("STATSD_HOST")
-    STATSD_PORT = 8125
-
     # The config option NOTIFY_ENVIRONMENT is purely used for logging.
     # It should not be used for any logical conditionals in the code.
     NOTIFY_ENVIRONMENT = os.environ["NOTIFY_ENVIRONMENT"]
@@ -90,7 +86,6 @@ class Development(Config):
 
     NOTIFICATION_QUEUE_PREFIX = "development"
     DEBUG = True
-    STATSD_ENABLED = False
 
     ANTIVIRUS_API_KEY = "test-key"
 
@@ -106,8 +101,6 @@ class Development(Config):
 
 class Test(Config):
     DEBUG = True
-    STATSD_HOST = "localhost"
-    STATSD_PORT = 1000
 
     ANTIVIRUS_API_KEY = "test-key"
 

--- a/requirements.in
+++ b/requirements.in
@@ -6,7 +6,7 @@ kombu @ git+https://github.com/celery/kombu.git@860e40a6c904c4d8551577d9f4e8c00f
 Flask-HTTPAuth~=4.8
 
 # Run `make bump-utils` to update to the latest version
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@115.0.1
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@117.0.1
 
 git+https://github.com/alphagov/gds_metrics_python.git@6f1840a57b6fb1ee40b7e84f2f18ec229de8aa72
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -667,7 +667,7 @@ mistune==0.8.4 \
     --hash=sha256:59a3429db53c50b5c6bcc8a07f8848cb00d7dc8bdb431a4ab41920d201d4756e \
     --hash=sha256:88a1051873018da288eee8538d476dffe1262495144b33ecb586c4ab266bb8d4
     # via notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@be88b9badd025dafe99d256f7661c45a68125c77
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b7b535c0cfb83e80f746568dbe43f8d7ac16f46f
     # via -r requirements.in
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \
@@ -1074,10 +1074,6 @@ six==1.17.0 \
 smartypants==2.0.2 \
     --hash=sha256:39d64ce1d7cc6964b698297bdf391bc12c3251b7f608e6e55d857cd7c5f800c6 \
     --hash=sha256:9471578606e8ee0740065bf8771f55fec8c83313cb98c5d1c1864ddd389d0f3a
-    # via notifications-utils
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
     # via notifications-utils
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \

--- a/requirements_for_test.txt
+++ b/requirements_for_test.txt
@@ -840,7 +840,7 @@ mistune==0.8.4 \
     # via
     #   -r requirements.txt
     #   notifications-utils
-notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@be88b9badd025dafe99d256f7661c45a68125c77
+notifications-utils @ git+https://github.com/alphagov/notifications-utils.git@b7b535c0cfb83e80f746568dbe43f8d7ac16f46f
     # via -r requirements.txt
 opentelemetry-api==1.40.0 \
     --hash=sha256:159be641c0b04d11e9ecd576906462773eb97ae1b657730f0ecf64d32071569f \
@@ -1360,12 +1360,6 @@ soupsieve==2.8.3 \
     --hash=sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349 \
     --hash=sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95
     # via beautifulsoup4
-statsd==4.0.1 \
-    --hash=sha256:99763da81bfea8daf6b3d22d11aaccb01a8d0f52ea521daab37e758a4ca7d128 \
-    --hash=sha256:c2676519927f7afade3723aca9ca8ea986ef5b059556a980a867721ca69df093
-    # via
-    #   -r requirements.txt
-    #   notifications-utils
 typing-extensions==4.15.0 \
     --hash=sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466 \
     --hash=sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548

--- a/requirements_for_test_common.in
+++ b/requirements_for_test_common.in
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@117.0.1
 
 beautifulsoup4
 pytest

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@117.0.1
 
 extend-exclude = [
     "migrations/versions/",

--- a/uv.toml
+++ b/uv.toml
@@ -1,4 +1,4 @@
-# This file was automatically copied from notifications-utils@115.0.1
+# This file was automatically copied from notifications-utils@117.0.1
 
 exclude-newer = "7 days"
 


### PR DESCRIPTION
https://trello.com/c/25A3gpXh/1358-replace-statsd-instrumentation-across-notify-with-otel

Currently live in dev-b (along with the corresponding changes in api and template-preview), FTs are passing.